### PR TITLE
fix: make sure tool names follow the required regex

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,10 +135,12 @@ class OpenAPIMCPServer {
           /[^a-zA-Z0-9-]/g,
           "-",
         );
+        const name = (op.operationId || op.summary || `${method.toUpperCase()} ${path}`)
+          .replace(/[^a-zA-Z0-9-]/g, "-");
+
         console.error(`Registering tool: ${toolId}`); // Debug logging
         const tool: Tool = {
-          name:
-            op.operationId || op.summary || `${method.toUpperCase()} ${path}`,
+          name,
           description:
             op.description ||
             `Make a ${method.toUpperCase()} request to ${path}`,


### PR DESCRIPTION
This is to fix an error that I encountered with my openapi spec that ended up builing tool names with spaces. Claude Desktop was complaining that these were invalid tool names because it did not meet the required regex: 'ToolDefinition.name: String should match pattern ^[a-zA- 20-9_-](1,64}$'