### PR TITLE
feat: add filters and dynamicTools-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 dist/
 node_modules/
+OPENAPI_ISSUE*

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The server can be configured through environment variables or command line argum
 - `HTTP_PORT` - Port for HTTP transport (default: 3000)
 - `HTTP_HOST` - Host for HTTP transport (default: "127.0.0.1")
 - `ENDPOINT_PATH` - Endpoint path for HTTP transport (default: "/mcp")
+- `TOOLS_MODE` - Tools loading mode: "all" (load all endpoint-based tools) or "dynamic" (load only meta-tools) (default: "all")
 
 ### Command Line Arguments
 
@@ -139,6 +140,32 @@ npx @ivotoby/openapi-mcp-server \
   --port 3000 \
   --host 127.0.0.1 \
   --path /mcp
+```
+
+### Tool Loading & Filtering Options
+
+Based on the Stainless article "What We Learned Converting Complex OpenAPI Specs to MCP Servers" (https://www.stainless.com/blog/what-we-learned-converting-complex-openapi-specs-to-mcp-servers), the following flags were added to control which API endpoints (tools) are loaded:
+
+- `--tools <all|dynamic>`: Choose to load all tools (default) or only dynamic meta-tools (`list_api_endpoints`, `get_api_endpoint_schema`, `invoke_api_endpoint`).
+- `--tool <toolId>`: Import only specified tool IDs or names. Can be used multiple times.
+- `--tag <tag>`: Import only tools with the specified OpenAPI tag. Can be used multiple times.
+- `--resource <resource>`: Import only tools under the specified resource path prefixes. Can be used multiple times.
+- `--operation <method>`: Import only tools for the specified HTTP methods (get, post, etc). Can be used multiple times.
+
+**Examples:**
+
+```bash
+# Load only dynamic meta-tools
+npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --tools dynamic
+
+# Load only the GET /users endpoint tool
+npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --tool GET-users
+
+# Load tools tagged with "user" under the "/users" resource
+npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --tag user --resource users
+
+# Load only POST operations
+npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --operation post
 ```
 
 ## Security Considerations
@@ -186,6 +213,26 @@ To see debug logs:
 3. Make your changes
 4. Run tests and linting: `npm run typecheck && npm run lint`
 5. Submit a pull request
+
+## FAQ
+
+**Q: What is a "tool"?**
+A: A tool corresponds to a single API endpoint derived from your OpenAPI specification, exposed as an MCP resource.
+
+**Q: How do I filter which tools are loaded?**
+A: Use the `--tool`, `--tag`, `--resource`, and `--operation` flags, or set `TOOLS_MODE=dynamic` for meta-tools only.
+
+**Q: When should I use dynamic mode?**
+A: Dynamic mode provides meta-tools (`list_api_endpoints`, `get_api_endpoint_schema`, `invoke_api_endpoint`) to inspect and interact with endpoints without preloading all operations, which is useful for large or changing APIs.
+
+**Q: How do I specify custom headers for API requests?**
+A: Use the `--headers` flag or `API_HEADERS` environment variable with `key:value` pairs separated by commas.
+
+**Q: Which transport methods are supported?**
+A: The server supports stdio transport (default) for integration with AI systems and HTTP transport (with streaming via SSE) for web clients.
+
+**Q: Where can I find development and contribution guidelines?**
+A: See the "For Developers" section above for commands (`npm run build`, `npm run dev`, etc) and pull request workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,36 @@ npx @ivotoby/openapi-mcp-server \
   --path /mcp
 ```
 
-### Tool Loading & Filtering Options
+### OpenAPI Schema Processing
+
+### Reference Resolution
+
+This MCP server implements robust OpenAPI reference (`$ref`) resolution to ensure accurate representation of API schemas:
+
+- **Parameter References**: Fully resolves `$ref` pointers to parameter components in the OpenAPI spec
+- **Schema References**: Handles nested schema references within parameters and request bodies
+- **Recursive References**: Prevents infinite loops by detecting and handling circular references
+- **Nested Properties**: Preserves complex nested object and array structures with all their attributes
+
+### Input Schema Composition
+
+The server intelligently merges parameters and request bodies into a unified input schema for each tool:
+
+- **Parameters + Request Body Merging**: Combines path, query, and body parameters into a single schema
+- **Collision Handling**: Resolves naming conflicts by prefixing body properties that conflict with parameter names
+- **Type Preservation**: Maintains the original type information for all schema elements
+- **Metadata Retention**: Preserves descriptions, formats, defaults, enums, and other schema attributes
+
+### Complex Schema Support
+
+The MCP server handles various OpenAPI schema complexities:
+
+- **Primitive Type Bodies**: Wraps non-object request bodies in a "body" property
+- **Object Bodies**: Flattens object properties into the tool's input schema
+- **Array Bodies**: Properly handles array schemas with their nested item definitions
+- **Required Properties**: Tracks and preserves which parameters and properties are required
+
+## Tool Loading & Filtering Options
 
 Based on the Stainless article "What We Learned Converting Complex OpenAPI Specs to MCP Servers" (https://www.stainless.com/blog/what-we-learned-converting-complex-openapi-specs-to-mcp-servers), the following flags were added to control which API endpoints (tools) are loaded:
 
@@ -230,6 +259,12 @@ A: Use the `--headers` flag or `API_HEADERS` environment variable with `key:valu
 
 **Q: Which transport methods are supported?**
 A: The server supports stdio transport (default) for integration with AI systems and HTTP transport (with streaming via SSE) for web clients.
+
+**Q: How does the server handle complex OpenAPI schemas with references?**
+A: The server fully resolves `$ref` references in parameters and schemas, preserving nested structures, default values, and other attributes. See the "OpenAPI Schema Processing" section for details on reference resolution and schema composition.
+
+**Q: What happens when parameter names conflict with request body properties?**
+A: The server detects naming conflicts and automatically prefixes body property names with `body_` to avoid collisions, ensuring all properties are accessible.
 
 **Q: Where can I find development and contribution guidelines?**
 A: See the "For Developers" section above for commands (`npm run build`, `npm run dev`, etc) and pull request workflow.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ npx @ivotoby/openapi-mcp-server \
 
 ### OpenAPI Schema Processing
 
-### Reference Resolution
+#### Reference Resolution
 
 This MCP server implements robust OpenAPI reference (`$ref`) resolution to ensure accurate representation of API schemas:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The MCP server handles various OpenAPI schema complexities:
 
 Based on the Stainless article "What We Learned Converting Complex OpenAPI Specs to MCP Servers" (https://www.stainless.com/blog/what-we-learned-converting-complex-openapi-specs-to-mcp-servers), the following flags were added to control which API endpoints (tools) are loaded:
 
-- `--tools <all|dynamic>`: Choose to load all tools (default) or only dynamic meta-tools (`list_api_endpoints`, `get_api_endpoint_schema`, `invoke_api_endpoint`).
+- `--tools <all|dynamic>`: Choose to load all tools (default) or only dynamic meta-tools (`list-api-endpoints`, `get-api-endpoint-schema`, `invoke-api-endpoint`).
 - `--tool <toolId>`: Import only specified tool IDs or names. Can be used multiple times.
 - `--tag <tag>`: Import only tools with the specified OpenAPI tag. Can be used multiple times.
 - `--resource <resource>`: Import only tools under the specified resource path prefixes. Can be used multiple times.
@@ -252,7 +252,7 @@ A: A tool corresponds to a single API endpoint derived from your OpenAPI specifi
 A: Use the `--tool`, `--tag`, `--resource`, and `--operation` flags, or set `TOOLS_MODE=dynamic` for meta-tools only.
 
 **Q: When should I use dynamic mode?**
-A: Dynamic mode provides meta-tools (`list_api_endpoints`, `get_api_endpoint_schema`, `invoke_api_endpoint`) to inspect and interact with endpoints without preloading all operations, which is useful for large or changing APIs.
+A: Dynamic mode provides meta-tools (`list-api-endpoints`, `get-api-endpoint-schema`, `invoke-api-endpoint`) to inspect and interact with endpoints without preloading all operations, which is useful for large or changing APIs.
 
 **Q: How do I specify custom headers for API requests?**
 A: Use the `--headers` flag or `API_HEADERS` environment variable with `key:value` pairs separated by commas.

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,16 @@ export interface OpenAPIMCPServerConfig {
   httpPort?: number
   httpHost?: string
   endpointPath?: string
+  /** Filter only specific tool IDs or names */
+  includeTools?: string[]
+  /** Filter only specific tags */
+  includeTags?: string[]
+  /** Filter only specific resources (path prefixes) */
+  includeResources?: string[]
+  /** Filter only specific HTTP methods: get,post,put,... */
+  includeOperations?: string[]
+  /** Tools loading mode: 'all' or 'dynamic' */
+  toolsMode: "all" | "dynamic"
 }
 
 /**
@@ -76,6 +86,31 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       type: "string",
       description: "Server version",
     })
+    .option("tools", {
+      type: "string",
+      choices: ["all", "dynamic"],
+      description: "Which tools to load: all or dynamic meta-tools",
+    })
+    .option("tool", {
+      type: "array",
+      string: true,
+      description: "Import only specified tool IDs or names",
+    })
+    .option("tag", {
+      type: "array",
+      string: true,
+      description: "Import only tools with specified OpenAPI tags",
+    })
+    .option("resource", {
+      type: "array",
+      string: true,
+      description: "Import only tools under specified resource path prefixes",
+    })
+    .option("operation", {
+      type: "array",
+      string: true,
+      description: "Import only tools for specified HTTP methods (e.g., get, post)",
+    })
     .help()
     .parseSync()
 
@@ -115,5 +150,10 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     httpPort,
     httpHost,
     endpointPath,
+    includeTools: argv.tool as string[] | undefined,
+    includeTags: argv.tag as string[] | undefined,
+    includeResources: argv.resource as string[] | undefined,
+    includeOperations: argv.operation as string[] | undefined,
+    toolsMode: (argv.tools as "all" | "dynamic") || process.env.TOOLS_MODE || "all",
   }
 }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -119,7 +119,8 @@ export class ToolsManager {
         // Get the operation for the method (get, post, etc.)
         const opObj = pathItem[methodLower]
         const tags: string[] = Array.isArray(opObj?.tags) ? (opObj.tags as string[]) : []
-        if (!tags.some((t: string) => this.config.includeTags!.includes(t))) continue
+        const includeTagsLower = this.config.includeTags.map((tag) => tag.toLowerCase())
+        if (!tags.some((tag) => includeTagsLower.includes(tag.toLowerCase()))) continue
       }
       filtered.set(toolId, tool)
     }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -20,16 +20,16 @@ export class ToolsManager {
   private createDynamicTools(): Map<string, Tool> {
     const dynamicTools = new Map<string, Tool>()
 
-    // list_api_endpoints
-    dynamicTools.set("list_api_endpoints", {
-      name: "list_api_endpoints",
+    // LIST-API-ENDPOINTS
+    dynamicTools.set("LIST-API-ENDPOINTS", {
+      name: "list-api-endpoints",
       description: "List all available API endpoints",
       inputSchema: { type: "object", properties: {} },
     })
 
-    // get_api_endpoint_schema
-    dynamicTools.set("get_api_endpoint_schema", {
-      name: "get_api_endpoint_schema",
+    // GET-API-ENDPOINT-SCHEMA
+    dynamicTools.set("GET-API-ENDPOINT-SCHEMA", {
+      name: "get-api-endpoint-schema",
       description: "Get the JSON schema for a specified API endpoint",
       inputSchema: {
         type: "object",
@@ -40,9 +40,9 @@ export class ToolsManager {
       },
     })
 
-    // invoke_api_endpoint
-    dynamicTools.set("invoke_api_endpoint", {
-      name: "invoke_api_endpoint",
+    // INVOKE-API-ENDPOINT
+    dynamicTools.set("INVOKE-API-ENDPOINT", {
+      name: "invoke-api-endpoint",
       description: "Invoke an API endpoint with provided parameters",
       inputSchema: {
         type: "object",

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -15,59 +15,61 @@ export class ToolsManager {
   }
 
   /**
+   * Create dynamic discovery meta-tools
+   */
+  private createDynamicTools(): Map<string, Tool> {
+    const dynamicTools = new Map<string, Tool>()
+
+    // list_api_endpoints
+    dynamicTools.set("list_api_endpoints", {
+      name: "list_api_endpoints",
+      description: "List all available API endpoints",
+      inputSchema: { type: "object", properties: {} },
+    })
+
+    // get_api_endpoint_schema
+    dynamicTools.set("get_api_endpoint_schema", {
+      name: "get_api_endpoint_schema",
+      description: "Get the JSON schema for a specified API endpoint",
+      inputSchema: {
+        type: "object",
+        properties: {
+          endpoint: { type: "string", description: "Endpoint path (e.g. /users/{id})" },
+        },
+        required: ["endpoint"],
+      },
+    })
+
+    // invoke_api_endpoint
+    dynamicTools.set("invoke_api_endpoint", {
+      name: "invoke_api_endpoint",
+      description: "Invoke an API endpoint with provided parameters",
+      inputSchema: {
+        type: "object",
+        properties: {
+          endpoint: { type: "string", description: "Endpoint path to invoke" },
+          params: {
+            type: "object",
+            description: "Parameters for the API call",
+            properties: {},
+          },
+        },
+        required: ["endpoint"],
+      },
+    })
+
+    return dynamicTools
+  }
+
+  /**
    * Initialize tools from the OpenAPI specification
    */
   async initialize(): Promise<void> {
     const spec = await this.specLoader.loadOpenAPISpec(this.config.openApiSpec)
     // Determine tools loading mode
     if (this.config.toolsMode === "dynamic") {
-      // Dynamic discovery meta-tools
-      const dynamicTools: [string, Tool][] = []
-      // list_api_endpoints
-      dynamicTools.push([
-        "list_api_endpoints",
-        {
-          name: "list_api_endpoints",
-          description: "List all available API endpoints",
-          inputSchema: { type: "object", properties: {} },
-        },
-      ])
-      // get_api_endpoint_schema
-      dynamicTools.push([
-        "get_api_endpoint_schema",
-        {
-          name: "get_api_endpoint_schema",
-          description: "Get the JSON schema for a specified API endpoint",
-          inputSchema: {
-            type: "object",
-            properties: {
-              endpoint: { type: "string", description: "Endpoint path (e.g. /users/{id})" },
-            },
-            required: ["endpoint"],
-          },
-        },
-      ])
-      // invoke_api_endpoint
-      dynamicTools.push([
-        "invoke_api_endpoint",
-        {
-          name: "invoke_api_endpoint",
-          description: "Invoke an API endpoint with provided parameters",
-          inputSchema: {
-            type: "object",
-            properties: {
-              endpoint: { type: "string", description: "Endpoint path to invoke" },
-              params: {
-                type: "object",
-                description: "Parameters for the API call",
-                properties: {},
-              },
-            },
-            required: ["endpoint"],
-          },
-        },
-      ])
-      this.tools = new Map(dynamicTools)
+      // Use dynamic discovery meta-tools
+      this.tools = this.createDynamicTools()
       return
     }
     // Load and filter standard tools

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -18,7 +18,104 @@ export class ToolsManager {
    */
   async initialize(): Promise<void> {
     const spec = await this.specLoader.loadOpenAPISpec(this.config.openApiSpec)
-    this.tools = this.specLoader.parseOpenAPISpec(spec)
+    // Determine tools loading mode
+    if (this.config.toolsMode === "dynamic") {
+      // Dynamic discovery meta-tools
+      const dynamicTools: [string, Tool][] = []
+      // list_api_endpoints
+      dynamicTools.push([
+        "list_api_endpoints",
+        {
+          name: "list_api_endpoints",
+          description: "List all available API endpoints",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ])
+      // get_api_endpoint_schema
+      dynamicTools.push([
+        "get_api_endpoint_schema",
+        {
+          name: "get_api_endpoint_schema",
+          description: "Get the JSON schema for a specified API endpoint",
+          inputSchema: {
+            type: "object",
+            properties: {
+              endpoint: { type: "string", description: "Endpoint path (e.g. /users/{id})" },
+            },
+            required: ["endpoint"],
+          },
+        },
+      ])
+      // invoke_api_endpoint
+      dynamicTools.push([
+        "invoke_api_endpoint",
+        {
+          name: "invoke_api_endpoint",
+          description: "Invoke an API endpoint with provided parameters",
+          inputSchema: {
+            type: "object",
+            properties: {
+              endpoint: { type: "string", description: "Endpoint path to invoke" },
+              params: {
+                type: "object",
+                description: "Parameters for the API call",
+                properties: {},
+              },
+            },
+            required: ["endpoint"],
+          },
+        },
+      ])
+      this.tools = new Map(dynamicTools)
+      return
+    }
+    // Load and filter standard tools
+    const rawTools = this.specLoader.parseOpenAPISpec(spec)
+    const filtered = new Map<string, Tool>()
+    // Helper to parse toolId into method and path
+    const parse = (id: string) => {
+      const [method, ...parts] = id.split("-")
+      const path = "/" + parts.join("/").replace(/-/g, "/")
+      return { method: method.toLowerCase(), path }
+    }
+    for (const [toolId, tool] of rawTools.entries()) {
+      // includeTools filter
+      if (this.config.includeTools && this.config.includeTools.length > 0) {
+        if (
+          !this.config.includeTools.includes(toolId) &&
+          !this.config.includeTools.includes(tool.name)
+        ) {
+          continue
+        }
+      }
+      // includeOperations filter
+      if (this.config.includeOperations && this.config.includeOperations.length > 0) {
+        const { method } = parse(toolId)
+        if (!this.config.includeOperations.map((op) => op.toLowerCase()).includes(method)) {
+          continue
+        }
+      }
+      // includeResources filter
+      if (this.config.includeResources && this.config.includeResources.length > 0) {
+        const { path } = parse(toolId)
+        // Match exact resource prefix (after leading slash)
+        const match = this.config.includeResources.some(
+          (res) => path === `/${res}` || path.startsWith(`/${res}/`),
+        )
+        if (!match) continue
+      }
+      // includeTags filter
+      if (this.config.includeTags && this.config.includeTags.length > 0) {
+        // Attempt to read tags from original spec paths
+        const { method, path } = parse(toolId)
+        // @ts-ignore: dynamic indexing of PathItemObject by method
+        const opObj: any = (spec.paths[path] as any)?.[method]
+        const tags: string[] = Array.isArray(opObj?.tags) ? (opObj.tags as string[]) : []
+        if (!tags.some((t: string) => this.config.includeTags!.includes(t))) continue
+      }
+      filtered.set(toolId, tool)
+    }
+    this.tools = filtered
 
     // Log the registered tools
     for (const [toolId, tool] of this.tools.entries()) {

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -76,9 +76,10 @@ export class ToolsManager {
     for (const [toolId, tool] of rawTools.entries()) {
       // includeTools filter
       if (this.config.includeTools && this.config.includeTools.length > 0) {
+        const includeToolsLower = this.config.includeTools.map((t) => t.toLowerCase())
         if (
-          !this.config.includeTools.includes(toolId) &&
-          !this.config.includeTools.includes(tool.name)
+          !includeToolsLower.includes(toolId.toLowerCase()) &&
+          !includeToolsLower.includes(tool.name.toLowerCase())
         ) {
           continue
         }
@@ -133,14 +134,18 @@ export class ToolsManager {
    * Find a tool by ID or name
    */
   findTool(idOrName: string): { toolId: string; tool: Tool } | undefined {
-    // Try to find by ID first
-    if (this.tools.has(idOrName)) {
-      return { toolId: idOrName, tool: this.tools.get(idOrName)! }
+    const lowerIdOrName = idOrName.toLowerCase()
+
+    // Try to find by ID first (case-insensitive)
+    for (const [toolId, tool] of this.tools.entries()) {
+      if (toolId.toLowerCase() === lowerIdOrName) {
+        return { toolId, tool }
+      }
     }
 
-    // Then try to find by name
+    // Then try to find by name (case-insensitive)
     for (const [toolId, tool] of this.tools.entries()) {
-      if (tool.name === idOrName) {
+      if (tool.name.toLowerCase() === lowerIdOrName) {
         return { toolId, tool }
       }
     }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -11,6 +11,8 @@ export class ToolsManager {
   private specLoader: OpenAPISpecLoader
 
   constructor(private config: OpenAPIMCPServerConfig) {
+    // Ensure toolsMode has a default value of 'all'
+    this.config.toolsMode = this.config.toolsMode || "all"
     this.specLoader = new OpenAPISpecLoader()
   }
 

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -1,6 +1,7 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js"
 import { OpenAPISpecLoader } from "./openapi-loader"
 import { OpenAPIMCPServerConfig } from "./config"
+import { OpenAPIV3 } from "openapi-types"
 
 /**
  * Manages the tools available in the MCP server
@@ -108,8 +109,13 @@ export class ToolsManager {
       if (this.config.includeTags && this.config.includeTags.length > 0) {
         // Attempt to read tags from original spec paths
         const { method, path } = this.parseToolId(toolId)
-        // @ts-ignore: dynamic indexing of PathItemObject by method
-        const opObj: any = (spec.paths[path] as any)?.[method.toLowerCase()]
+        const methodLower = method.toLowerCase() as OpenAPIV3.HttpMethods
+        const pathItem = spec.paths[path] as OpenAPIV3.PathItemObject | undefined
+
+        if (!pathItem) continue
+
+        // Get the operation for the method (get, post, etc.)
+        const opObj = pathItem[methodLower]
         const tags: string[] = Array.isArray(opObj?.tags) ? (opObj.tags as string[]) : []
         if (!tags.some((t: string) => this.config.includeTags!.includes(t))) continue
       }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -101,9 +101,11 @@ export class ToolsManager {
       // includeResources filter
       if (this.config.includeResources && this.config.includeResources.length > 0) {
         const { path } = this.parseToolId(toolId)
-        // Match exact resource prefix (after leading slash)
+        const pathLower = path.toLowerCase()
+        // Match exact resource prefix (after leading slash) - case insensitive
         const match = this.config.includeResources.some(
-          (res) => path === `/${res}` || path.startsWith(`/${res}/`),
+          (res) =>
+            pathLower === `/${res}`.toLowerCase() || pathLower.startsWith(`/${res}/`.toLowerCase()),
         )
         if (!match) continue
       }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -107,6 +107,11 @@ describe("loadConfig", () => {
       httpPort: 3000,
       httpHost: "127.0.0.1",
       endpointPath: "/mcp",
+      includeTools: undefined,
+      includeTags: undefined,
+      includeResources: undefined,
+      includeOperations: undefined,
+      toolsMode: "all",
     })
   })
 
@@ -194,6 +199,11 @@ describe("loadConfig", () => {
       httpPort: 3000,
       httpHost: "127.0.0.1",
       endpointPath: "/mcp",
+      includeTools: undefined,
+      includeTags: undefined,
+      includeResources: undefined,
+      includeOperations: undefined,
+      toolsMode: "all",
     })
   })
 

--- a/test/openapi-loader.test.ts
+++ b/test/openapi-loader.test.ts
@@ -290,6 +290,38 @@ paths:
       expect(tools.has("GET-users")).toBe(true)
     })
 
+    it("should skip non-HTTP methods in path item", () => {
+      const specWithNonHttpMethods: OpenAPIV3.Document = {
+        ...mockOpenAPISpec,
+        paths: {
+          "/api/users": {
+            // Valid HTTP method
+            get: {
+              operationId: "getUsers",
+              responses: {},
+            },
+            // Non-HTTP method property that should be skipped
+            servers: [{ url: "https://api.example.com" }],
+            // Another non-HTTP method that should be skipped
+            summary: "Users API endpoint",
+            // Another valid HTTP method
+            post: {
+              operationId: "createUser",
+              responses: {},
+            },
+          },
+        },
+      }
+
+      const tools = openAPILoader.parseOpenAPISpec(specWithNonHttpMethods)
+      expect(tools.size).toBe(2)
+      expect(tools.has("GET-api-users")).toBe(true)
+      expect(tools.has("POST-api-users")).toBe(true)
+      // Verify non-HTTP methods aren't included
+      expect([...tools.keys()].some((key) => key.startsWith("SERVERS-"))).toBe(false)
+      expect([...tools.keys()].some((key) => key.startsWith("SUMMARY-"))).toBe(false)
+    })
+
     // New tests for Input Schema Composition and $ref inlining
     it("should merge primitive request bodies into a 'body' property and mark required", () => {
       const spec: OpenAPIV3.Document = {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -32,6 +32,7 @@ const config: OpenAPIMCPServerConfig = {
   httpPort: 3000,
   httpHost: "127.0.0.1",
   endpointPath: "/mcp",
+  toolsMode: "all",
 }
 
 describe("OpenAPIServer", () => {

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -1,31 +1,31 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { ToolsManager } from '../src/tools-manager'
-import { OpenAPISpecLoader } from '../src/openapi-loader'
-import { Tool } from '@modelcontextprotocol/sdk/types.js'
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest"
+import { ToolsManager } from "../src/tools-manager"
+import { OpenAPISpecLoader } from "../src/openapi-loader"
+import { Tool } from "@modelcontextprotocol/sdk/types.js"
 
 // Mock dependencies
-vi.mock('../src/openapi-loader', () => {
+vi.mock("../src/openapi-loader", () => {
   return {
     OpenAPISpecLoader: vi.fn().mockImplementation(() => ({
       loadOpenAPISpec: vi.fn(),
-      parseOpenAPISpec: vi.fn()
-    }))
+      parseOpenAPISpec: vi.fn(),
+    })),
   }
 })
 
-describe('ToolsManager', () => {
+describe("ToolsManager", () => {
   let toolsManager: ToolsManager
   let mockConfig: any
   let mockSpecLoader: any
 
   beforeEach(() => {
     mockConfig = {
-      name: 'test-server',
-      version: '1.0.0',
-      apiBaseUrl: 'http://example.com/api',
-      openApiSpec: 'http://example.com/openapi.json'
+      name: "test-server",
+      version: "1.0.0",
+      apiBaseUrl: "http://example.com/api",
+      openApiSpec: "http://example.com/openapi.json",
     }
-    
+
     toolsManager = new ToolsManager(mockConfig)
     mockSpecLoader = (toolsManager as any).specLoader
   })
@@ -34,12 +34,12 @@ describe('ToolsManager', () => {
     vi.clearAllMocks()
   })
 
-  describe('initialize', () => {
-    it('should load and parse the OpenAPI spec', async () => {
+  describe("initialize", () => {
+    it("should load and parse the OpenAPI spec", async () => {
       const mockSpec = { paths: {} }
       const mockTools = new Map([
-        ['GET-users', { name: 'List Users', description: 'Get all users' } as Tool],
-        ['POST-users', { name: 'Create User', description: 'Create a new user' } as Tool]
+        ["GET-users", { name: "List Users", description: "Get all users" } as Tool],
+        ["POST-users", { name: "Create User", description: "Create a new user" } as Tool],
       ])
 
       mockSpecLoader.loadOpenAPISpec.mockResolvedValue(mockSpec)
@@ -51,92 +51,161 @@ describe('ToolsManager', () => {
       expect(mockSpecLoader.parseOpenAPISpec).toHaveBeenCalledWith(mockSpec)
       expect((toolsManager as any).tools).toEqual(mockTools)
     })
-  })
 
-  describe('getAllTools', () => {
-    it('should return all tools', async () => {
-      const mockTools = new Map([
-        ['GET-users', { name: 'List Users' } as Tool],
-        ['POST-users', { name: 'Create User' } as Tool]
-      ])
-      
-      // Set up the tools map
-      vi.spyOn(toolsManager as any, 'tools', 'get').mockReturnValue(mockTools)
-      
-      const tools = toolsManager.getAllTools()
-      
+    it("should load dynamic meta-tools when toolsMode is dynamic", async () => {
+      // Configure for dynamic mode
+      ;(toolsManager as any).config.toolsMode = "dynamic"
+      const spyLoad = mockSpecLoader.loadOpenAPISpec.mockResolvedValue({} as any)
+      await toolsManager.initialize()
+      // parseOpenAPISpec should not be called
+      expect(mockSpecLoader.parseOpenAPISpec).not.toHaveBeenCalled()
+      const tools = toolsManager.getAllTools().map((t) => t.name)
       expect(tools).toEqual([
-        { name: 'List Users' },
-        { name: 'Create User' }
+        "list_api_endpoints",
+        "get_api_endpoint_schema",
+        "invoke_api_endpoint",
       ])
+    })
+
+    it("should filter tools by includeTools list", async () => {
+      // Setup raw tools
+      const mockTools = new Map([
+        ["GET-foo", { name: "foo" } as Tool],
+        ["GET-bar", { name: "bar" } as Tool],
+      ])
+      mockSpecLoader.loadOpenAPISpec.mockResolvedValue({ paths: {} } as any)
+      mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
+      ;(toolsManager as any).config.toolsMode = "all"
+      ;(toolsManager as any).config.includeTools = ["GET-bar"]
+      await toolsManager.initialize()
+      expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET-bar"])
+    })
+
+    it("should filter tools by includeOperations list", async () => {
+      const mockTools = new Map([
+        ["GET-1", { name: "g1" } as Tool],
+        ["POST-1", { name: "p1" } as Tool],
+      ])
+      mockSpecLoader.loadOpenAPISpec.mockResolvedValue({ paths: {} } as any)
+      mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
+      ;(toolsManager as any).config.toolsMode = "all"
+      ;(toolsManager as any).config.includeOperations = ["get"]
+      await toolsManager.initialize()
+      expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET-1"])
+    })
+
+    it("should filter tools by includeResources list", async () => {
+      const mockTools = new Map([
+        ["GET-users", { name: "u" } as Tool],
+        ["GET-orders-id", { name: "o" } as Tool],
+      ])
+      mockSpecLoader.loadOpenAPISpec.mockResolvedValue({ paths: {} } as any)
+      mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
+      ;(toolsManager as any).config.toolsMode = "all"
+      ;(toolsManager as any).config.includeResources = ["users"]
+      await toolsManager.initialize()
+      expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET-users"])
+    })
+
+    it("should filter tools by includeTags list", async () => {
+      const spec = {
+        paths: {
+          "/a": { get: { tags: ["x"] } },
+          "/b": { get: { tags: ["y"] } },
+        },
+      } as any
+      const mockTools = new Map([
+        ["GET-a", { name: "a" } as Tool],
+        ["GET-b", { name: "b" } as Tool],
+      ])
+      mockSpecLoader.loadOpenAPISpec.mockResolvedValue(spec)
+      mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
+      ;(toolsManager as any).config.toolsMode = "all"
+      ;(toolsManager as any).config.includeTags = ["x"]
+      await toolsManager.initialize()
+      expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET-a"])
     })
   })
 
-  describe('findTool', () => {
-    it('should find a tool by ID', () => {
+  describe("getAllTools", () => {
+    it("should return all tools", async () => {
       const mockTools = new Map([
-        ['GET-users', { name: 'List Users' } as Tool],
-        ['POST-users', { name: 'Create User' } as Tool]
+        ["GET-users", { name: "List Users" } as Tool],
+        ["POST-users", { name: "Create User" } as Tool],
       ])
-      
+
       // Set up the tools map
-      vi.spyOn(toolsManager as any, 'tools', 'get').mockReturnValue(mockTools)
-      
-      const result = toolsManager.findTool('GET-users')
-      
+      vi.spyOn(toolsManager as any, "tools", "get").mockReturnValue(mockTools)
+
+      const tools = toolsManager.getAllTools()
+
+      expect(tools).toEqual([{ name: "List Users" }, { name: "Create User" }])
+    })
+  })
+
+  describe("findTool", () => {
+    it("should find a tool by ID", () => {
+      const mockTools = new Map([
+        ["GET-users", { name: "List Users" } as Tool],
+        ["POST-users", { name: "Create User" } as Tool],
+      ])
+
+      // Set up the tools map
+      vi.spyOn(toolsManager as any, "tools", "get").mockReturnValue(mockTools)
+
+      const result = toolsManager.findTool("GET-users")
+
       expect(result).toEqual({
-        toolId: 'GET-users',
-        tool: { name: 'List Users' }
+        toolId: "GET-users",
+        tool: { name: "List Users" },
       })
     })
 
-    it('should find a tool by name', () => {
+    it("should find a tool by name", () => {
       const mockTools = new Map([
-        ['GET-users', { name: 'List Users' } as Tool],
-        ['POST-users', { name: 'Create User' } as Tool]
+        ["GET-users", { name: "List Users" } as Tool],
+        ["POST-users", { name: "Create User" } as Tool],
       ])
-      
+
       // Set up the tools map
-      vi.spyOn(toolsManager as any, 'tools', 'get').mockReturnValue(mockTools)
-      
-      const result = toolsManager.findTool('Create User')
-      
+      vi.spyOn(toolsManager as any, "tools", "get").mockReturnValue(mockTools)
+
+      const result = toolsManager.findTool("Create User")
+
       expect(result).toEqual({
-        toolId: 'POST-users',
-        tool: { name: 'Create User' }
+        toolId: "POST-users",
+        tool: { name: "Create User" },
       })
     })
 
-    it('should return undefined if tool is not found', () => {
-      const mockTools = new Map([
-        ['GET-users', { name: 'List Users' } as Tool]
-      ])
-      
+    it("should return undefined if tool is not found", () => {
+      const mockTools = new Map([["GET-users", { name: "List Users" } as Tool]])
+
       // Set up the tools map
-      vi.spyOn(toolsManager as any, 'tools', 'get').mockReturnValue(mockTools)
-      
-      const result = toolsManager.findTool('nonexistent')
-      
+      vi.spyOn(toolsManager as any, "tools", "get").mockReturnValue(mockTools)
+
+      const result = toolsManager.findTool("nonexistent")
+
       expect(result).toBeUndefined()
     })
   })
 
-  describe('parseToolId', () => {
-    it('should parse a tool ID into method and path', () => {
-      const result = toolsManager.parseToolId('GET-users-active')
-      
+  describe("parseToolId", () => {
+    it("should parse a tool ID into method and path", () => {
+      const result = toolsManager.parseToolId("GET-users-active")
+
       expect(result).toEqual({
-        method: 'GET',
-        path: '/users/active'
+        method: "GET",
+        path: "/users/active",
       })
     })
 
-    it('should handle complex paths with hyphens', () => {
-      const result = toolsManager.parseToolId('POST-api-v1-user-profile-update')
-      
+    it("should handle complex paths with hyphens", () => {
+      const result = toolsManager.parseToolId("POST-api-v1-user-profile-update")
+
       expect(result).toEqual({
-        method: 'POST',
-        path: '/api/v1/user/profile/update'
+        method: "POST",
+        path: "/api/v1/user/profile/update",
       })
     })
   })

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -125,6 +125,25 @@ describe("ToolsManager", () => {
       await toolsManager.initialize()
       expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET-a"])
     })
+
+    it("should filter tools by includeTags list case-insensitively", async () => {
+      const spec = {
+        paths: {
+          "/a": { get: { tags: ["USERS"] } },
+          "/b": { get: { tags: ["products"] } },
+        },
+      } as any
+      const mockTools = new Map([
+        ["GET-a", { name: "a" } as Tool],
+        ["GET-b", { name: "b" } as Tool],
+      ])
+      mockSpecLoader.loadOpenAPISpec.mockResolvedValue(spec)
+      mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
+      ;(toolsManager as any).config.toolsMode = "all"
+      ;(toolsManager as any).config.includeTags = ["users"] // lowercase, will match uppercase "USERS"
+      await toolsManager.initialize()
+      expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET-a"])
+    })
   })
 
   describe("getAllTools", () => {

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -61,9 +61,9 @@ describe("ToolsManager", () => {
       expect(mockSpecLoader.parseOpenAPISpec).not.toHaveBeenCalled()
       const tools = toolsManager.getAllTools().map((t) => t.name)
       expect(tools).toEqual([
-        "list_api_endpoints",
-        "get_api_endpoint_schema",
-        "invoke_api_endpoint",
+        "list-api-endpoints",
+        "get-api-endpoint-schema",
+        "invoke-api-endpoint",
       ])
     })
 

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -146,7 +146,7 @@ describe("ToolsManager", () => {
     })
   })
 
-  describe("getAllTools", () => {
+  describe("getAllTools - return all tools", () => {
     it("should return all tools", async () => {
       const mockTools = new Map([
         ["GET-users", { name: "List Users" } as Tool],


### PR DESCRIPTION
This pull request introduces significant enhancements to the tool-loading functionality of the OpenAPI MCP server, including new filtering options, schema handling improvements, and updated documentation. The changes improve flexibility in tool selection, streamline request body schema processing, and enhance documentation for better user understanding.

### Tool Loading Enhancements:
* Added `TOOLS_MODE` environment variable and `--tools` CLI flag to control tool-loading mode (`all` or `dynamic`). Dynamic mode loads meta-tools only (`list_api_endpoints`, `get_api_endpoint_schema`, `invoke_api_endpoint`). (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R128) `src/config.ts` [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R14-R23) `src/tools-manager.ts` [[3]](diffhunk://#diff-261563fdb6b5208a055698e0ca4cc264f14b04696c7639e53dc60b6b7dfc595eL21-R118)
* Introduced new CLI flags (`--tool`, `--tag`, `--resource`, `--operation`) and corresponding configuration properties (`includeTools`, `includeTags`, etc.) to filter tools by ID, OpenAPI tags, resource paths, or HTTP methods. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R170) `src/config.ts` [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R14-R23) [[3]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R89-R113) [[4]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R153-R157)

### Schema Handling Improvements:
* Added an `inlineSchema` method to handle `$ref` resolution and recursive cycles in OpenAPI schemas. This ensures schemas are fully inlined and avoids infinite recursion. (`src/openapi-loader.ts` [src/openapi-loader.tsR44-R100](diffhunk://#diff-713f69fd7b5450ae2368c8cbecb40426827987a703ad953ad45ee1326057233aR44-R100))
* Enhanced request body schema processing to merge parameters and request bodies into a unified input schema, handling name collisions by prefixing. (`src/openapi-loader.ts` [src/openapi-loader.tsL73-R189](diffhunk://#diff-713f69fd7b5450ae2368c8cbecb40426827987a703ad953ad45ee1326057233aL73-R189))

### Documentation Updates:
* Expanded the `README.md` with a new "Tool Loading & Filtering Options" section, providing examples for using the new CLI flags and tool-loading modes. (`README.md` [README.mdR145-R170](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R170))
* Added an FAQ section to clarify key concepts such as tools, filtering, and dynamic mode usage. (`README.md` [README.mdR217-R236](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R217-R236))

### Testing Enhancements:
* Added new test cases for input schema composition, `$ref` inlining, and request body merging to validate the new functionality. (`test/openapi-loader.test.ts` [test/openapi-loader.test.tsR292-R444](diffhunk://#diff-34fbb37407132fe60b0aa923c7293c30b201d5c8ef3e3a34aa18aa456845540eR292-R444))

### Minor Changes:
* Updated `loadConfig` tests to include new configuration properties. (`test/config.test.ts` [[1]](diffhunk://#diff-68554a83416cb0dc26af312268fd38ba6024f0f1b222d37b984fd2d2032a26d5R110-R114) [[2]](diffhunk://#diff-68554a83416cb0dc26af312268fd38ba6024f0f1b222d37b984fd2d2032a26d5R202-R206)
