### PR TITLE
fix(api-client.ts): interpolate path parameters into URL and remove them from params to ensure correct URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To see debug logs:
 
 2. When using HTTP transport:
    ```bash
-   npx @ivotoby/openapi-mcp-server --transport http 2>debug.log
+   npx @ivotoby/openapi-mcp-server --transport http &2>debug.log
    ```
 
 ## For Developers

--- a/scripts/path-parameters-validation.mjs
+++ b/scripts/path-parameters-validation.mjs
@@ -73,9 +73,9 @@ function demonstratePathParameterHandling() {
   console.log("Case 2: Multiple path parameters with OpenAPI definition")
   console.log("----------------------------------------------------")
   const pathDefs2 = {
-    orderId: { location: "path" },
-    itemId: { location: "path" },
-    withDetails: { location: "query" },
+    orderId: { 'x-parameter-location': "path" },
+    itemId: { 'x-parameter-location': "path" },
+    withDetails: { 'x-parameter-location': "query" },
   }
   const result2 = processUrl(
     "/store/order/orderId/item/itemId",

--- a/scripts/path-parameters-validation.mjs
+++ b/scripts/path-parameters-validation.mjs
@@ -31,7 +31,7 @@ function demonstratePathParameterHandling() {
       // Check each parameter to see if it's a path parameter
       for (const [key, value] of Object.entries(paramsCopy)) {
         const paramDef = paramDefs[key]
-        const paramLocation = paramDef?.location
+        const paramLocation = paramDef?.['x-parameter-location']
 
         // If it's a path parameter, interpolate it
         if (paramLocation === "path") {

--- a/scripts/path-parameters-validation.mjs
+++ b/scripts/path-parameters-validation.mjs
@@ -62,8 +62,8 @@ function demonstratePathParameterHandling() {
   console.log("Case 1: Simple path parameter with OpenAPI definition")
   console.log("--------------------------------------------------")
   const pathDefs1 = {
-    petId: { location: "path" },
-    format: { location: "query" },
+    petId: { 'x-parameter-location': "path" },
+    format: { 'x-parameter-location': "query" },
   }
   const result1 = processUrl("/pet/petId", { petId: 1, format: "json" }, pathDefs1)
   console.log(`URL: ${result1.url}`)

--- a/scripts/path-parameters-validation.mjs
+++ b/scripts/path-parameters-validation.mjs
@@ -1,0 +1,110 @@
+/**
+ * Validation script for path parameter handling
+ *
+ * This script demonstrates how path parameters are now handled in the API client:
+ * 1. When path parameters are defined in OpenAPI spec with `in: "path"`, they're properly
+ *    interpolated into the URL path
+ * 2. Parameters are removed from the query string/body after being used in the path
+ * 3. Only explicitly marked path parameters are substituted, preventing query parameters
+ *    from being incorrectly applied to the path
+ */
+
+// Since we can't directly import the ApiClient from dist (bundled),
+// this is a simplified demo of the path parameter handling logic
+
+/**
+ * Simplified demonstration of path parameter handling
+ */
+function demonstratePathParameterHandling() {
+  console.log("Path Parameter Handling Demonstration")
+  console.log("====================================\n")
+
+  // Simplified implementation of our path parameter handling
+  function processUrl(path, params, paramDefs) {
+    const paramsCopy = { ...params }
+    let resolvedPath = path
+
+    // With parameter metadata from OpenAPI
+    if (paramDefs) {
+      console.log("Using OpenAPI parameter definitions:")
+
+      // Check each parameter to see if it's a path parameter
+      for (const [key, value] of Object.entries(paramsCopy)) {
+        const paramDef = paramDefs[key]
+        const paramLocation = paramDef?.location
+
+        // If it's a path parameter, interpolate it
+        if (paramLocation === "path") {
+          resolvedPath = resolvedPath.replace(`/${key}`, `/${value}`)
+          delete paramsCopy[key]
+        }
+      }
+    } else {
+      console.log("Fallback without OpenAPI definitions:")
+
+      // Fallback behavior if tool definition is not available
+      for (const key of Object.keys(paramsCopy)) {
+        if (resolvedPath.includes(`/${key}`)) {
+          const value = paramsCopy[key]
+          resolvedPath = resolvedPath.replace(`/${key}`, `/${value}`)
+          delete paramsCopy[key]
+        }
+      }
+    }
+
+    return {
+      url: resolvedPath,
+      remainingParams: paramsCopy,
+    }
+  }
+
+  // Case 1: Simple path parameter with OpenAPI definitions
+  console.log("Case 1: Simple path parameter with OpenAPI definition")
+  console.log("--------------------------------------------------")
+  const pathDefs1 = {
+    petId: { location: "path" },
+    format: { location: "query" },
+  }
+  const result1 = processUrl("/pet/petId", { petId: 1, format: "json" }, pathDefs1)
+  console.log(`URL: ${result1.url}`)
+  console.log(`Remaining parameters: ${JSON.stringify(result1.remainingParams)}\n`)
+
+  // Case 2: Multiple path parameters with OpenAPI definitions
+  console.log("Case 2: Multiple path parameters with OpenAPI definition")
+  console.log("----------------------------------------------------")
+  const pathDefs2 = {
+    orderId: { location: "path" },
+    itemId: { location: "path" },
+    withDetails: { location: "query" },
+  }
+  const result2 = processUrl(
+    "/store/order/orderId/item/itemId",
+    { orderId: 123, itemId: 456, withDetails: true },
+    pathDefs2,
+  )
+  console.log(`URL: ${result2.url}`)
+  console.log(`Remaining parameters: ${JSON.stringify(result2.remainingParams)}\n`)
+
+  // Case 3: Parameter with same name as path segment with OpenAPI definitions
+  console.log("Case 3: Parameter matching path segment name but defined as query parameter")
+  console.log("---------------------------------------------------------------------")
+  const pathDefs3 = {
+    query: { location: "query" },
+    results: { location: "query" },
+  }
+  const result3 = processUrl("/search/results", { query: "test", results: "json" }, pathDefs3)
+  console.log(`URL: ${result3.url}`)
+  console.log(`Remaining parameters: ${JSON.stringify(result3.remainingParams)}\n`)
+
+  // Case 4: Path parameter handler without OpenAPI definitions (fallback)
+  console.log("Case 4: Fallback behavior without OpenAPI definitions")
+  console.log("--------------------------------------------------")
+  const result4 = processUrl("/pet/petId", { petId: 1, format: "json" })
+  console.log(`URL: ${result4.url}`)
+  console.log(`Remaining parameters: ${JSON.stringify(result4.remainingParams)}\n`)
+
+  console.log("Demonstration complete! ✅")
+}
+
+// Run the demonstration
+demonstratePathParameterHandling()

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -61,6 +61,11 @@ export class ApiClient {
       const paramsCopy: Record<string, any> = { ...params }
       let resolvedPath = path
 
+      // Helper function to escape regex special characters
+      const escapeRegExp = (str: string): string => {
+        return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") // $& means the whole matched string
+      }
+
       // Handle path parameters
       if (toolDef?.inputSchema?.properties) {
         // Check each parameter to see if it's a path parameter
@@ -72,8 +77,10 @@ export class ApiClient {
 
           // If it's a path parameter, interpolate it into the URL and remove from params
           if (paramLocation === "path") {
+            // Escape key before using it in regex patterns
+            const escapedKey = escapeRegExp(key)
             // Try standard OpenAPI and Express-style parameters first
-            const paramRegex = new RegExp(`\\{${key}\\}|:${key}(?:\\/|$)`, "g")
+            const paramRegex = new RegExp(`\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)`, "g")
 
             // If specific parameter style was found, use it
             if (paramRegex.test(resolvedPath)) {
@@ -92,8 +99,10 @@ export class ApiClient {
         // Fallback behavior if tool definition is not available
         for (const key of Object.keys(paramsCopy)) {
           const value = paramsCopy[key]
+          // Escape key before using it in regex patterns
+          const escapedKey = escapeRegExp(key)
           // First try standard OpenAPI and Express-style parameters
-          const paramRegex = new RegExp(`\\{${key}\\}|:${key}(?:\\/|$)`, "g")
+          const paramRegex = new RegExp(`\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)`, "g")
 
           // If found, replace using regex
           if (paramRegex.test(resolvedPath)) {

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -54,9 +54,13 @@ export class OpenAPISpecLoader {
         if (method === "parameters" || !operation) continue
 
         // Skip invalid HTTP methods
-        if (!["get", "post", "put", "patch", "delete", "options", "head"].includes(method.toLowerCase())) {
-          console.log(`Skipping non-HTTP method "${method}" for path ${path}`);
-          continue;
+        if (
+          !["get", "post", "put", "patch", "delete", "options", "head"].includes(
+            method.toLowerCase(),
+          )
+        ) {
+          console.log(`Skipping non-HTTP method "${method}" for path ${path}`)
+          continue
         }
 
         const op = operation as OpenAPIV3.OperationObject
@@ -87,6 +91,7 @@ export class OpenAPISpecLoader {
                 tool.inputSchema.properties[param.name] = {
                   type: paramSchema.type || "string",
                   description: param.description || `${param.name} parameter`,
+                  "x-parameter-location": param.in, // Store parameter location (path, query, etc.)
                 }
               }
               // Add required parameters to our temporary array

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -123,7 +123,7 @@ export class OpenAPISpecLoader {
             method.toLowerCase(),
           )
         ) {
-          console.log(`Skipping non-HTTP method "${method}" for path ${path}`)
+          console.warn(`Skipping non-HTTP method "${method}" for path ${path}`)
           continue
         }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprot
 import { OpenAPIMCPServerConfig } from "./config"
 import { ToolsManager } from "./tools-manager"
 import { ApiClient } from "./api-client"
+import { Tool } from "@modelcontextprotocol/sdk/types.js"
 
 /**
  * MCP server implementation for OpenAPI specifications
@@ -101,6 +102,15 @@ export class OpenAPIServer {
    */
   async start(transport: Transport): Promise<void> {
     await this.toolsManager.initialize()
+    // Pass the tools to the API client
+    const toolsMap = new Map<string, Tool>()
+    this.toolsManager.getAllTools().forEach((tool) => {
+      const toolInfo = this.toolsManager.findTool(tool.name)
+      if (toolInfo) {
+        toolsMap.set(toolInfo.toolId, tool)
+      }
+    })
+    this.apiClient.setTools(toolsMap)
     await this.server.connect(transport)
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,12 +104,9 @@ export class OpenAPIServer {
     await this.toolsManager.initialize()
     // Pass the tools to the API client
     const toolsMap = new Map<string, Tool>()
-    this.toolsManager.getAllTools().forEach((tool) => {
-      const toolInfo = this.toolsManager.findTool(tool.name)
-      if (toolInfo) {
-        toolsMap.set(toolInfo.toolId, tool)
-      }
-    })
+    for (const [toolId, tool] of this.toolsManager.getToolsWithIds()) {
+      toolsMap.set(toolId, tool)
+    }
     this.apiClient.setTools(toolsMap)
     await this.server.connect(transport)
   }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -14,7 +14,7 @@ export class ToolsManager {
     // Ensure toolsMode has a default value of 'all'
     this.config.toolsMode = this.config.toolsMode || "all"
     this.specLoader = new OpenAPISpecLoader({
-      disableAbbreviation: this.config.disableAbbreviation
+      disableAbbreviation: this.config.disableAbbreviation,
     })
   }
 
@@ -154,6 +154,14 @@ export class ToolsManager {
    */
   getAllTools(): Tool[] {
     return Array.from(this.tools.values())
+  }
+
+  /**
+   * Get all available tools with their IDs
+   * Returns array of [toolId, tool] pairs
+   */
+  getToolsWithIds(): [string, Tool][] {
+    return Array.from(this.tools.entries())
   }
 
   /**

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -11,11 +11,11 @@ describe("ApiClient", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    
+
     // Setup mock axios instance
     mockAxiosInstance = vi.fn().mockResolvedValue({ data: { result: "success" } })
     vi.mocked(axios.create).mockReturnValue(mockAxiosInstance as any)
-    
+
     // Create ApiClient instance
     apiClient = new ApiClient("https://api.example.com", { "X-API-Key": "test-key" })
   })
@@ -38,34 +38,37 @@ describe("ApiClient", () => {
   describe("executeApiCall", () => {
     it("should make GET request with correct parameters", async () => {
       await apiClient.executeApiCall("GET-users-list", { page: 1, limit: 10 })
-      
+
       expect(mockAxiosInstance).toHaveBeenCalledWith({
         method: "get",
         url: "/users/list",
         headers: { "X-API-Key": "test-key" },
-        params: { page: 1, limit: 10 }
+        params: { page: 1, limit: 10 },
       })
     })
 
     it("should make POST request with correct body", async () => {
-      await apiClient.executeApiCall("POST-users-create", { name: "John", email: "john@example.com" })
-      
+      await apiClient.executeApiCall("POST-users-create", {
+        name: "John",
+        email: "john@example.com",
+      })
+
       expect(mockAxiosInstance).toHaveBeenCalledWith({
         method: "post",
         url: "/users/create",
         headers: { "X-API-Key": "test-key" },
-        data: { name: "John", email: "john@example.com" }
+        data: { name: "John", email: "john@example.com" },
       })
     })
 
     it("should convert array parameters to comma-separated strings for GET requests", async () => {
       await apiClient.executeApiCall("GET-users-search", { tags: ["admin", "active"] })
-      
+
       expect(mockAxiosInstance).toHaveBeenCalledWith({
         method: "get",
         url: "/users/search",
         headers: { "X-API-Key": "test-key" },
-        params: { tags: "admin,active" }
+        params: { tags: "admin,active" },
       })
     })
 
@@ -78,45 +81,57 @@ describe("ApiClient", () => {
       const axiosError = new Error("Request failed") as any
       axiosError.response = {
         status: 404,
-        data: { error: "Not found" }
+        data: { error: "Not found" },
       }
-      
+
       mockAxiosInstance.mockRejectedValueOnce(axiosError)
       vi.mocked(axios.isAxiosError).mockReturnValueOnce(true)
-      
-      await expect(apiClient.executeApiCall("GET-users-list", {}))
-        .rejects
-        .toThrow("API request failed: Request failed (404: {\"error\":\"Not found\"})")
+
+      await expect(apiClient.executeApiCall("GET-users-list", {})).rejects.toThrow(
+        'API request failed: Request failed (404: {"error":"Not found"})',
+      )
     })
 
     it("should handle non-axios errors", async () => {
       const error = new Error("Network error")
       mockAxiosInstance.mockRejectedValueOnce(error)
       vi.mocked(axios.isAxiosError).mockReturnValueOnce(false)
-      
-      await expect(apiClient.executeApiCall("GET-users-list", {}))
-        .rejects
-        .toThrow("Network error")
+
+      await expect(apiClient.executeApiCall("GET-users-list", {})).rejects.toThrow("Network error")
+    })
+
+    it("should replace path parameters in URL correctly and remove them from query parameters", async () => {
+      await apiClient.executeApiCall("GET-pet-petId", { petId: 1, filter: "all" })
+      expect(mockAxiosInstance).toHaveBeenCalledWith({
+        method: "get",
+        url: "/pet/1",
+        headers: { "X-API-Key": "test-key" },
+        params: { filter: "all" },
+      })
     })
   })
 
   describe("parseToolId", () => {
     it("should correctly parse tool ID into method and path", async () => {
       await apiClient.executeApiCall("GET-users-profile-details", {})
-      
-      expect(mockAxiosInstance).toHaveBeenCalledWith(expect.objectContaining({
-        method: "get",
-        url: "/users/profile/details"
-      }))
+
+      expect(mockAxiosInstance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "get",
+          url: "/users/profile/details",
+        }),
+      )
     })
 
     it("should handle hyphens in path segments", async () => {
       await apiClient.executeApiCall("POST-api-v1-user-profile", {})
-      
-      expect(mockAxiosInstance).toHaveBeenCalledWith(expect.objectContaining({
-        method: "post",
-        url: "/api/v1/user/profile"
-      }))
+
+      expect(mockAxiosInstance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "post",
+          url: "/api/v1/user/profile",
+        }),
+      )
     })
   })
 })

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -207,6 +207,94 @@ describe("ApiClient", () => {
         params: { query: "test", results: "json" },
       })
     })
+
+    it("should handle OpenAPI-style path parameters with curly braces", async () => {
+      // Create a mock tool with OpenAPI-style parameter in path
+      const mockTool = {
+        name: "get-user-by-id",
+        description: "Get user by ID",
+        inputSchema: {
+          type: "object",
+          properties: {
+            userId: {
+              type: "string",
+              description: "User ID",
+              "x-parameter-location": "path",
+            },
+          },
+        },
+      }
+
+      // Set up the tool in the client and mock parseToolId to return path with {userId}
+      const toolsMap = new Map()
+      toolsMap.set("GET-user-userId", mockTool)
+      apiClient.setTools(toolsMap)
+
+      // Mock the parseToolId method to return a path with curly braces format
+      const originalParseToolId = (apiClient as any).parseToolId
+      ;(apiClient as any).parseToolId = vi.fn().mockReturnValue({
+        method: "get",
+        path: "/user/{userId}",
+      })
+
+      // Execute the call
+      await apiClient.executeApiCall("GET-user-userId", { userId: "user123" })
+
+      // Verify the correct URL was constructed
+      expect(mockAxiosInstance).toHaveBeenCalledWith({
+        method: "get",
+        url: "/user/user123",
+        headers: { "X-API-Key": "test-key" },
+        params: {},
+      })
+
+      // Restore original parseToolId
+      ;(apiClient as any).parseToolId = originalParseToolId
+    })
+
+    it("should handle Express-style path parameters with colon prefix", async () => {
+      // Create a mock tool with Express-style parameter in path
+      const mockTool = {
+        name: "get-user-by-id",
+        description: "Get user by ID",
+        inputSchema: {
+          type: "object",
+          properties: {
+            userId: {
+              type: "string",
+              description: "User ID",
+              "x-parameter-location": "path",
+            },
+          },
+        },
+      }
+
+      // Set up the tool in the client and mock parseToolId to return path with :userId
+      const toolsMap = new Map()
+      toolsMap.set("GET-user-userId", mockTool)
+      apiClient.setTools(toolsMap)
+
+      // Mock the parseToolId method to return a path with Express format
+      const originalParseToolId = (apiClient as any).parseToolId
+      ;(apiClient as any).parseToolId = vi.fn().mockReturnValue({
+        method: "get",
+        path: "/user/:userId",
+      })
+
+      // Execute the call
+      await apiClient.executeApiCall("GET-user-userId", { userId: "user123" })
+
+      // Verify the correct URL was constructed
+      expect(mockAxiosInstance).toHaveBeenCalledWith({
+        method: "get",
+        url: "/user/user123",
+        headers: { "X-API-Key": "test-key" },
+        params: {},
+      })
+
+      // Restore original parseToolId
+      ;(apiClient as any).parseToolId = originalParseToolId
+    })
   })
 
   describe("parseToolId", () => {

--- a/test/openapi-loader.test.ts
+++ b/test/openapi-loader.test.ts
@@ -195,15 +195,15 @@ paths:
             get: {
               operationId: "getUserManagementAuthorizationGroups",
               summary: "Get all user management authorization groups",
-              responses: {}
-            }
-          }
-        }
+              responses: {},
+            },
+          },
+        },
       }
-      
+
       const tools = loader.parseOpenAPISpec(spec)
       const toolId = Array.from(tools.keys())[0]
-      
+
       // Should not be abbreviated
       expect(toolId).toContain("GET-users-management-authorization-groups")
       const tool = tools.get(toolId)!
@@ -554,11 +554,13 @@ paths:
       expect(properties.id).toEqual({
         type: "string",
         description: "Item identifier",
+        "x-parameter-location": "path",
       })
 
       expect(properties.limit).toEqual({
         type: "integer",
         description: "Maximum number of results",
+        "x-parameter-location": "query",
       })
 
       // Verify that required parameters were correctly identified
@@ -634,6 +636,7 @@ paths:
       const filterParam = properties.filter as Record<string, any>
       expect(filterParam.type).toBe("object")
       expect(filterParam.description).toBe("Product filtering options")
+      expect(filterParam["x-parameter-location"]).toBe("query")
       // Check that nested properties are preserved
       expect(filterParam.properties).toBeDefined()
       expect(filterParam.properties.category).toBeDefined()
@@ -646,6 +649,7 @@ paths:
       const paginationParam = properties.pagination as Record<string, any>
       expect(paginationParam.type).toBe("object")
       expect(paginationParam.description).toBe("Pagination options")
+      expect(paginationParam["x-parameter-location"]).toBe("query")
       // Check that nested properties with defaults are preserved
       expect(paginationParam.properties).toBeDefined()
       expect(paginationParam.properties.page).toBeDefined()
@@ -666,7 +670,7 @@ paths:
       const loader = new OpenAPISpecLoader({ disableAbbreviation: true })
       const longName = "ServiceUsersManagementController_updateServiceUsersAuthorityGroup"
       const result = loader.abbreviateOperationId(longName)
-      
+
       // Should not be abbreviated
       expect(result).toContain("service-users-management-controller")
       expect(result).toContain("update-service-users-authority-group")

--- a/test/openapi-loader.test.ts
+++ b/test/openapi-loader.test.ts
@@ -207,6 +207,7 @@ paths:
           limit: {
             type: "integer",
             description: "Maximum number of users to return",
+            "x-parameter-location": "query",
           },
         },
       })
@@ -223,6 +224,7 @@ paths:
           id: {
             type: "string",
             description: "User ID",
+            "x-parameter-location": "path",
           },
         },
         required: ["id"],

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -68,6 +68,7 @@ describe("OpenAPIServer", () => {
       () =>
         ({
           executeApiCall: vi.fn(),
+          setTools: vi.fn(),
         }) as any,
     )
 

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -162,6 +162,25 @@ describe("ToolsManager", () => {
     })
   })
 
+  describe("getToolsWithIds", () => {
+    it("should return all tools with their IDs", async () => {
+      const mockTools = new Map([
+        ["GET-users", { name: "List Users" } as Tool],
+        ["POST-users", { name: "Create User" } as Tool],
+      ])
+
+      // Set up the tools map
+      vi.spyOn(toolsManager as any, "tools", "get").mockReturnValue(mockTools)
+
+      const toolsWithIds = toolsManager.getToolsWithIds()
+
+      expect(toolsWithIds).toEqual([
+        ["GET-users", { name: "List Users" }],
+        ["POST-users", { name: "Create User" }],
+      ])
+    })
+  })
+
   describe("findTool", () => {
     it("should find a tool by ID", () => {
       const mockTools = new Map([


### PR DESCRIPTION
**Enhanced OpenAPI parsing**: Modified openapi-loader.ts to store each parameter's location (path, query, etc.) in the tool definition using an x-parameter-location property.

**Improved API client path parameter handling**: 
Updated api-client.ts to:
- Expose the setTools method to receive tool definitions
- Update the executeApiCall method to intelligently handle path parameters when tools are available
- Only replace path segments marked as path parameters in the OpenAPI spec
- Keep backward compatibility with the previous approach as a fallback

**Connected the tools with the API client**: Modified server.ts to pass tools from ToolsManager to the ApiClient so it can access parameter metadata.

**Added comprehensive tests**: Added several test cases covering various path parameter scenarios:
Basic path parameter replacement

**Multiple path parameters**
- Query parameters with the same name as path segments (preventing unintended substitution)
- Using OpenAPI parameter locations to correctly distinguish types

**Created a validation script**: Added path-parameters-validation.mjs that demonstrates the path parameter handling behavior, showing:
- Parameters marked as path parameters are properly substituted in the URL
- Other parameters remain in the query or body
- When tool definitions aren't available, it falls back to the previous behavior

Fixes https://github.com/ivo-toby/mcp-openapi-server/issues/15