### PR TITLE
feat: Add disableAbbreviation configuration option

### DIFF
--- a/scripts/inspect.js
+++ b/scripts/inspect.js
@@ -28,6 +28,9 @@ if (process.env.SERVER_NAME) {
 if (process.env.API_HEADERS) {
   args.push(`--headers=${process.env.API_HEADERS}`);
 }
+if (process.env.DISABLE_ABBREVIATION) {
+  args.push(`--disable-abbreviation=${process.env.DISABLE_ABBREVIATION}`);
+}
 
 // Execute the command
 import { spawn } from 'child_process';

--- a/scripts/test-http-transport.sh
+++ b/scripts/test-http-transport.sh
@@ -16,6 +16,7 @@ while [[ "$#" -gt 0 ]]; do
     --path) PATH="$2"; shift ;;
     --api-base-url) API_BASE_URL="$2"; shift ;;
     --openapi-spec) OPENAPI_SPEC="$2"; shift ;;
+    --disable-abbreviation) DISABLE_ABBREVIATION="$2"; shift ;;
     *) echo "Unknown parameter: $1"; exit 1 ;;
   esac
   shift
@@ -30,6 +31,7 @@ show_usage() {
   echo "  --path PATH         Path (default: /mcp)"
   echo "  --api-base-url URL  API base URL"
   echo "  --openapi-spec URL  OpenAPI spec URL"
+  echo "  --disable-abbreviation Boolean  Disable name optimization"
   exit 1
 }
 
@@ -55,7 +57,8 @@ node dist/bundle.js \
   --host $HOST \
   --path $PATH \
   --api-base-url $API_BASE_URL \
-  --openapi-spec $OPENAPI_SPEC &
+  --openapi-spec $OPENAPI_SPEC \
+  --disable-abbreviation $DISABLE_ABBREVIATION &
 
 SERVER_PID=$!
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export interface OpenAPIMCPServerConfig {
   includeOperations?: string[]
   /** Tools loading mode: 'all' or 'dynamic' */
   toolsMode: "all" | "dynamic"
+  disableAbbreviation?: boolean
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,6 +112,10 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       string: true,
       description: "Import only tools for specified HTTP methods (e.g., get, post)",
     })
+    .option("disable-abbreviation", {
+      type: "boolean",
+      description: "Disable name optimization",
+    })
     .help()
     .parseSync()
 
@@ -131,6 +135,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
   // Combine CLI args and env vars, with CLI taking precedence
   const apiBaseUrl = argv["api-base-url"] || process.env.API_BASE_URL
   const openApiSpec = argv["openapi-spec"] || process.env.OPENAPI_SPEC_PATH
+  const disableAbbreviation = argv["disable-abbreviation"] || (process.env.DISABLE_ABBREVIATION ? process.env.DISABLE_ABBREVIATION === 'true' : false)
 
   if (!apiBaseUrl) {
     throw new Error("API base URL is required (--api-base-url or API_BASE_URL)")
@@ -156,5 +161,6 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     includeResources: argv.resource as string[] | undefined,
     includeOperations: argv.operation as string[] | undefined,
     toolsMode: (argv.tools as "all" | "dynamic") || process.env.TOOLS_MODE || "all",
+    disableAbbreviation: disableAbbreviation ? true : undefined,
   }
 }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -13,7 +13,9 @@ export class ToolsManager {
   constructor(private config: OpenAPIMCPServerConfig) {
     // Ensure toolsMode has a default value of 'all'
     this.config.toolsMode = this.config.toolsMode || "all"
-    this.specLoader = new OpenAPISpecLoader()
+    this.specLoader = new OpenAPISpecLoader({
+      disableAbbreviation: this.config.disableAbbreviation
+    })
   }
 
   /**

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -232,4 +232,106 @@ describe("loadConfig", () => {
     expect(config.version).toBe("1.0.0")
     expect(config.transportType).toBe("stdio")
   })
+
+  it("should handle disableAbbreviation from command line and environment", async () => {
+    // Test with command line argument
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+          "disable-abbreviation": true
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    // Import the module after setting up mocks
+    let { loadConfig } = await import("../src/config")
+    let config = loadConfig()
+    expect(config.disableAbbreviation).toBe(true)
+
+    // Reset modules for next test
+    vi.resetModules()
+
+    // Test with environment variable (string 'true')
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    process.env.DISABLE_ABBREVIATION = 'true'
+    
+    // Import the module again after resetting
+    const configModule = await import("../src/config")
+    loadConfig = configModule.loadConfig
+    config = loadConfig()
+    expect(config.disableAbbreviation).toBe(true)
+
+    // Reset modules for next test
+    vi.resetModules()
+
+    // Test with environment variable (string 'false')
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    process.env.DISABLE_ABBREVIATION = 'false'
+    
+    // Import the module again after resetting
+    const configModule2 = await import("../src/config")
+    loadConfig = configModule2.loadConfig
+    config = loadConfig()
+    expect(config.disableAbbreviation).toBeUndefined()
+
+    // Test default value (undefined)
+    vi.resetModules()
+    delete process.env.DISABLE_ABBREVIATION
+
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    const configModule3 = await import("../src/config")
+    loadConfig = configModule3.loadConfig
+    config = loadConfig()
+    expect(config.disableAbbreviation).toBeUndefined()
+  })
 })

--- a/test/openapi-loader.test.ts
+++ b/test/openapi-loader.test.ts
@@ -184,6 +184,33 @@ paths:
     })
   })
 
+  describe("parseOpenAPISpec with disableAbbreviation", () => {
+    it("should not abbreviate tool names when disableAbbreviation is true", () => {
+      const loader = new OpenAPISpecLoader({ disableAbbreviation: true })
+      const spec: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/users/management/authorization-groups": {
+            get: {
+              operationId: "getUserManagementAuthorizationGroups",
+              summary: "Get all user management authorization groups",
+              responses: {}
+            }
+          }
+        }
+      }
+      
+      const tools = loader.parseOpenAPISpec(spec)
+      const toolId = Array.from(tools.keys())[0]
+      
+      // Should not be abbreviated
+      expect(toolId).toContain("GET-users-management-authorization-groups")
+      const tool = tools.get(toolId)!
+      expect(tool.name).toContain("get-user-management-authorization-groups")
+    })
+  })
+
   describe("parseOpenAPISpec", () => {
     it("should convert OpenAPI paths to MCP tools", () => {
       const tools = openAPILoader.parseOpenAPISpec(mockOpenAPISpec)
@@ -629,6 +656,18 @@ paths:
       // Neither parameter should be required
       const required = tool!.inputSchema.required
       expect(required).toBeUndefined()
+    })
+  })
+
+  describe("disableAbbreviation", () => {
+    it("should not abbreviate operation IDs when disableAbbreviation is true", () => {
+      const loader = new OpenAPISpecLoader({ disableAbbreviation: true })
+      const longName = "ServiceUsersManagementController_updateServiceUsersAuthorityGroup"
+      const result = loader.abbreviateOperationId(longName)
+      
+      // Should not be abbreviated
+      expect(result).toContain("service-users-management-controller")
+      expect(result).toContain("update-service-users-authority-group")
     })
   })
 


### PR DESCRIPTION
feat: Add disableAbbreviation configuration option

## Changes
- Added `disableAbbreviation` configuration option to control operation ID abbreviation
- When `disableAbbreviation` is `true`, original operation IDs are preserved with only basic formatting
- Added comprehensive test cases to verify the behavior when abbreviation is disabled

## Technical Details
- Modified `abbreviateOperationId` to respect the `disableAbbreviation` flag
- Updated test cases to ensure proper functionality

## Testing
- Added unit tests verifying that operation IDs remain unabbreviated when `disableAbbreviation` is `true`
- Verified that tool names in `parseOpenAPISpec` respect the abbreviation setting

## Impact
This change allows users to preserve original operation IDs when needed, which can be useful for:
- Better readability and debugging
- Maintaining consistency with existing API documentation
- Cases where abbreviation might cause ambiguity