### PR TITLE
fix(mcp-server.js): update import path to use cli.js instead of bundle.js

### DIFF
--- a/bin/mcp-server.js
+++ b/bin/mcp-server.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-import "../dist/bundle.js";
+import "../dist/cli.js"

--- a/build.js
+++ b/build.js
@@ -1,4 +1,8 @@
-import * as esbuild from "esbuild";
+import * as esbuild from "esbuild"
+
+console.log("Building OpenAPI MCP Server...")
+
+// Build the main library bundle (for importing)
 await esbuild.build({
   entryPoints: ["./src/index.ts"],
   bundle: true,
@@ -11,9 +15,33 @@ await esbuild.build({
     "@modelcontextprotocol/sdk/server/index.js",
     "@modelcontextprotocol/sdk/server/stdio.js",
     "@modelcontextprotocol/sdk/server/transport.js",
-    "@modelcontextprotocol/sdk/types.js"
+    "@modelcontextprotocol/sdk/types.js",
+    "@modelcontextprotocol/sdk/shared/transport.js",
   ],
   banner: {
     js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);`,
   },
-});
+})
+
+// Build the CLI entry point
+await esbuild.build({
+  entryPoints: ["./src/cli.ts"],
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  outfile: "./dist/cli.js",
+  target: "node18",
+  external: [
+    "@modelcontextprotocol/sdk",
+    "@modelcontextprotocol/sdk/server/index.js",
+    "@modelcontextprotocol/sdk/server/stdio.js",
+    "@modelcontextprotocol/sdk/server/transport.js",
+    "@modelcontextprotocol/sdk/types.js",
+    "@modelcontextprotocol/sdk/shared/transport.js",
+  ],
+  banner: {
+    js: `#!/usr/bin/env node\nimport { createRequire } from 'module';const require = createRequire(import.meta.url);`,
+  },
+})
+
+console.log("✅ Build complete!")

--- a/docs/auth-provider-guide.md
+++ b/docs/auth-provider-guide.md
@@ -1,0 +1,221 @@
+# AuthProvider Usage Guide
+
+The `@ivotoby/openapi-mcp-server` now supports dynamic authentication through the `AuthProvider` interface. This is particularly useful for APIs that require token refresh or have authentication tokens that expire.
+
+## Basic Usage
+
+### Static Authentication (Backward Compatible)
+
+```typescript
+import { OpenAPIServer } from '@ivotoby/openapi-mcp-server'
+
+const config = {
+  name: 'my-api-server',
+  version: '1.0.0',
+  apiBaseUrl: 'https://api.example.com',
+  openApiSpec: './api-spec.yaml',
+  specInputMethod: 'file',
+  headers: {
+    'Authorization': 'Bearer your-static-token',
+    'X-API-Key': 'your-api-key'
+  },
+  transportType: 'stdio',
+  toolsMode: 'all'
+}
+
+const server = new OpenAPIServer(config)
+```
+
+### Dynamic Authentication with AuthProvider
+
+```typescript
+import { OpenAPIServer, AuthProvider } from '@ivotoby/openapi-mcp-server'
+import { AxiosError } from 'axios'
+
+class MyAuthProvider implements AuthProvider {
+  private accessToken: string | null = null
+  private tokenExpiry: Date | null = null
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    // Check if token is still valid
+    if (!this.accessToken || this.isTokenExpired()) {
+      throw new Error('Token expired. Please provide a new token.')
+    }
+
+    return {
+      'Authorization': `Bearer ${this.accessToken}`,
+      'X-Client-Version': '1.0.0'
+    }
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    // Check if this is an authentication error
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      // Try to refresh the token (if you have refresh logic)
+      try {
+        await this.refreshToken()
+        return true // Retry the request
+      } catch (refreshError) {
+        // If refresh fails, ask user for new token
+        throw new Error('Authentication failed. Please provide a new access token.')
+      }
+    }
+    
+    // Not an auth error, don't retry
+    return false
+  }
+
+  setToken(token: string, expiresIn: number = 3600) {
+    this.accessToken = token
+    this.tokenExpiry = new Date(Date.now() + expiresIn * 1000)
+  }
+
+  private isTokenExpired(): boolean {
+    return !this.tokenExpiry || this.tokenExpiry <= new Date()
+  }
+
+  private async refreshToken(): Promise<void> {
+    // Implement your token refresh logic here
+    // This might involve calling a refresh endpoint
+    throw new Error('Token refresh not implemented')
+  }
+}
+
+// Usage
+const authProvider = new MyAuthProvider()
+authProvider.setToken('your-initial-token', 3600)
+
+const config = {
+  name: 'my-api-server',
+  version: '1.0.0',
+  apiBaseUrl: 'https://api.example.com',
+  openApiSpec: './api-spec.yaml',
+  specInputMethod: 'file',
+  authProvider: authProvider, // Use AuthProvider instead of headers
+  transportType: 'stdio',
+  toolsMode: 'all'
+}
+
+const server = new OpenAPIServer(config)
+```
+
+## AuthProvider Interface
+
+```typescript
+interface AuthProvider {
+  /**
+   * Get authentication headers for the current request
+   * This method is called before each API request to get fresh headers
+   * 
+   * @returns Promise that resolves to headers object
+   * @throws Error if authentication is not available (e.g., token expired)
+   */
+  getAuthHeaders(): Promise<Record<string, string>>
+
+  /**
+   * Handle authentication errors from API responses
+   * This is called when the API returns authentication-related errors (401, 403)
+   * 
+   * @param error - The axios error from the failed request
+   * @returns Promise that resolves to true if the request should be retried, false otherwise
+   */
+  handleAuthError(error: AxiosError): Promise<boolean>
+}
+```
+
+## Key Features
+
+### 1. Dynamic Headers per Request
+Unlike static headers that are set once, `getAuthHeaders()` is called before each API request, allowing for:
+- Token refresh
+- Dynamic header generation
+- Token validation before requests
+
+### 2. Authentication Error Handling
+When the API returns 401 or 403 errors, `handleAuthError()` is called, allowing you to:
+- Attempt token refresh
+- Prompt users for new credentials
+- Decide whether to retry the request
+
+### 3. Automatic Retry Logic
+If `handleAuthError()` returns `true`, the request is automatically retried with fresh headers from `getAuthHeaders()`. The retry only happens once to prevent infinite loops.
+
+### 4. Backward Compatibility
+Existing code using static headers continues to work unchanged. The system internally creates a `StaticAuthProvider` when headers are provided without an `AuthProvider`.
+
+## Example: Manual Token Updates
+
+For APIs like Beatport where automatic refresh isn't possible, you can create an AuthProvider that prompts for new tokens:
+
+```typescript
+class ManualTokenAuthProvider implements AuthProvider {
+  private token: string | null = null
+  private tokenExpiry: Date | null = null
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    if (!this.token || this.isTokenExpired()) {
+      throw new Error(
+        'Token expired. Please get a new token from your browser and update it using the updateToken command.'
+      )
+    }
+
+    return { 'Authorization': `Bearer ${this.token}` }
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    // For manual token management, we can't auto-retry
+    // Throw a helpful error message instead
+    throw new Error(
+      'Authentication failed. Please get a new access token from your browser:\\n' +
+      '1. Go to https://api.example.com\\n' +
+      '2. Open browser dev tools\\n' +
+      '3. Copy the Authorization header\\n' +
+      '4. Use the updateToken command to set the new token'
+    )
+  }
+
+  updateToken(token: string, expiresIn: number = 3600): void {
+    this.token = token
+    this.tokenExpiry = new Date(Date.now() + expiresIn * 1000)
+    console.log('✅ Token updated successfully')
+  }
+
+  private isTokenExpired(): boolean {
+    if (!this.tokenExpiry) return true
+    return this.tokenExpiry <= new Date(Date.now() + 60000) // 1 minute buffer
+  }
+}
+```
+
+## Error Handling Best Practices
+
+1. **Clear Error Messages**: Provide actionable error messages that tell users exactly what to do
+2. **Graceful Degradation**: Don't crash the server when tokens expire
+3. **User Guidance**: Include step-by-step instructions for token renewal
+4. **Retry Logic**: Only retry when it makes sense (e.g., after successful token refresh)
+
+## Migration from Static Headers
+
+To migrate existing code:
+
+**Before:**
+```typescript
+const config = {
+  // ... other config
+  headers: { 'Authorization': 'Bearer token' }
+}
+```
+
+**After:**
+```typescript
+const authProvider = new MyAuthProvider()
+authProvider.setToken('token')
+
+const config = {
+  // ... other config
+  authProvider: authProvider
+  // Remove the headers property
+}
+```
+
+The AuthProvider approach provides much more flexibility and better error handling for modern APIs with dynamic authentication requirements.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,238 @@
+# Examples
+
+This directory contains comprehensive examples demonstrating how to use `@ivotoby/openapi-mcp-server` as a library to create dedicated MCP servers for specific APIs.
+
+## Overview
+
+The `@ivotoby/openapi-mcp-server` package can be used in two ways:
+
+1. **CLI Tool**: Use `npx @ivotoby/openapi-mcp-server` directly with command-line arguments
+2. **Library**: Import and use the `OpenAPIServer` class in your own Node.js applications
+
+These examples focus on the **library usage**, showing how to create dedicated, customized MCP servers for specific APIs.
+
+## Examples Included
+
+### 1. [Basic Library Usage](./basic-library-usage/)
+
+**Purpose**: Demonstrates the simplest way to use the library with static authentication.
+
+**Key Features**:
+
+- Basic `OpenAPIServer` configuration
+- Static header authentication
+- Stdio transport for Claude Desktop integration
+- Minimal setup for quick prototyping
+
+**When to use**: When you have a simple API with static authentication and want to get started quickly.
+
+### 2. [AuthProvider Example](./auth-provider-example/)
+
+**Purpose**: Showcases the `AuthProvider` interface for dynamic authentication scenarios.
+
+**Key Features**:
+
+- Multiple AuthProvider implementations (Refreshable, Manual, API Key)
+- Token expiration handling
+- Authentication error recovery
+- Dynamic header generation
+
+**When to use**: When your API requires token refresh, has expiring tokens, or needs complex authentication logic.
+
+### 3. [Beatport Example](./beatport-example/)
+
+**Purpose**: Real-world implementation for the Beatport API demonstrating production-ready patterns.
+
+**Key Features**:
+
+- Custom AuthProvider for manual token management
+- API endpoint filtering and optimization
+- Comprehensive error handling with user guidance
+- Production-ready packaging and distribution
+
+**When to use**: As a template for creating production-ready MCP servers for specific APIs.
+
+## Key Concepts Demonstrated
+
+### Library vs CLI Usage
+
+**CLI Usage** (what most users start with):
+
+```bash
+npx @ivotoby/openapi-mcp-server \
+  --api-base-url https://api.example.com \
+  --openapi-spec https://api.example.com/openapi.json \
+  --headers "Authorization:Bearer token"
+```
+
+**Library Usage** (what these examples show):
+
+```typescript
+import { OpenAPIServer } from "@ivotoby/openapi-mcp-server"
+
+const server = new OpenAPIServer({
+  name: "my-api-server",
+  apiBaseUrl: "https://api.example.com",
+  openApiSpec: "https://api.example.com/openapi.json",
+  headers: { Authorization: "Bearer token" },
+})
+```
+
+### AuthProvider Interface
+
+The `AuthProvider` interface enables dynamic authentication:
+
+```typescript
+interface AuthProvider {
+  getAuthHeaders(): Promise<Record<string, string>>
+  handleAuthError(error: AxiosError): Promise<boolean>
+}
+```
+
+**Benefits**:
+
+- Fresh headers for each request
+- Token expiration handling
+- Authentication error recovery
+- Runtime token updates
+
+### Configuration Options
+
+All examples demonstrate different configuration patterns:
+
+- **Transport Types**: Stdio (Claude Desktop) vs HTTP (web clients)
+- **Tool Loading**: All endpoints vs filtered subsets vs dynamic meta-tools
+- **Authentication**: Static headers vs dynamic AuthProvider
+- **API Filtering**: Include/exclude specific endpoints, operations, or tags
+
+## Getting Started
+
+### 1. Choose Your Pattern
+
+- **Simple API with static auth** → Start with [Basic Library Usage](./basic-library-usage/)
+- **API with token expiration** → Use [AuthProvider Example](./auth-provider-example/)
+- **Production deployment** → Follow [Beatport Example](./beatport-example/) patterns
+
+### 2. Copy and Customize
+
+Each example is a complete, standalone project:
+
+1. Copy the example directory
+2. Update `package.json` with your details
+3. Modify the configuration for your API
+4. Implement custom authentication if needed
+5. Build and deploy
+
+### 3. Package for Distribution
+
+Examples show how to create distributable packages:
+
+```json
+{
+  "name": "my-api-mcp-server",
+  "bin": {
+    "my-api-mcp-server": "dist/index.js"
+  }
+}
+```
+
+Users can then install and use your server:
+
+```bash
+npx my-api-mcp-server
+```
+
+## Common Patterns
+
+### Static Authentication
+
+```typescript
+const config = {
+  // ... other config
+  headers: {
+    Authorization: "Bearer token",
+    "X-API-Key": "key",
+  },
+}
+```
+
+### Dynamic Authentication
+
+```typescript
+const authProvider = new MyAuthProvider()
+const config = {
+  // ... other config
+  authProvider: authProvider,
+}
+```
+
+### API Filtering
+
+```typescript
+const config = {
+  // ... other config
+  includeOperations: ["get", "post"],
+  includeResources: ["users", "posts"],
+  includeTags: ["public"],
+}
+```
+
+### Error Handling
+
+```typescript
+class MyAuthProvider implements AuthProvider {
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    if (error.response?.status === 401) {
+      // Provide clear instructions
+      throw new Error("Token expired. Please...")
+    }
+    return false
+  }
+}
+```
+
+## Benefits of Library Usage
+
+### 1. Customization
+
+- Custom authentication logic
+- API-specific optimizations
+- Custom error handling
+- Additional tools and features
+
+### 2. Distribution
+
+- Package as standalone npm modules
+- Version control and updates
+- Easy installation for users
+- Professional deployment
+
+### 3. Integration
+
+- Embed in larger applications
+- Custom transport implementations
+- Integration with existing auth systems
+- Custom middleware and processing
+
+### 4. Maintenance
+
+- API-specific documentation
+- Tailored user experience
+- Focused feature set
+- Better error messages
+
+## Next Steps
+
+1. **Explore the Examples**: Start with the basic example and work your way up
+2. **Read the Documentation**: Check the main README for all configuration options
+3. **Implement Your API**: Use the patterns to create your own dedicated server
+4. **Share Your Work**: Consider publishing your server for others to use
+
+## Contributing
+
+Found a useful pattern or want to add an example? Contributions are welcome!
+
+- Add new examples for different authentication patterns
+- Improve existing examples with better error handling
+- Add examples for specific popular APIs
+- Document advanced configuration patterns

--- a/examples/auth-provider-example/README.md
+++ b/examples/auth-provider-example/README.md
@@ -1,0 +1,222 @@
+# AuthProvider Example
+
+This example demonstrates how to use the `AuthProvider` interface with `@ivotoby/openapi-mcp-server` for dynamic authentication scenarios.
+
+## Overview
+
+The `AuthProvider` interface allows you to handle complex authentication scenarios that static headers cannot address:
+
+- **Token Expiration**: Automatically detect and handle expired tokens
+- **Token Refresh**: Automatically refresh tokens when they expire
+- **Manual Token Updates**: Handle APIs that require manual token renewal
+- **API Key Management**: Manage API keys with validation
+- **Custom Authentication**: Implement any authentication pattern
+
+## Examples Included
+
+### 1. RefreshableAuthProvider
+
+Automatically refreshes tokens using a refresh token when they expire.
+
+**Use case**: OAuth2 APIs with refresh tokens
+
+```typescript
+const authProvider = new RefreshableAuthProvider(
+  "https://api.example.com/oauth/token", // Token refresh URL
+  "initial-access-token", // Initial access token
+  "initial-refresh-token", // Initial refresh token
+)
+```
+
+**Features**:
+
+- Automatic token refresh before expiration
+- Retry logic for authentication errors
+- Token expiry tracking with buffer time
+
+### 2. ManualTokenAuthProvider
+
+Handles APIs that require manual token updates (like Beatport).
+
+**Use case**: APIs where automatic refresh isn't possible
+
+```typescript
+const authProvider = new ManualTokenAuthProvider("MyAPI")
+authProvider.updateToken("your-bearer-token-here", 3600)
+```
+
+**Features**:
+
+- Manual token updates
+- Clear error messages with instructions
+- Token status tracking
+- Expiry warnings
+
+### 3. ApiKeyAuthProvider
+
+Simple API key authentication with validation.
+
+**Use case**: APIs that use API keys instead of bearer tokens
+
+```typescript
+const authProvider = new ApiKeyAuthProvider(
+  "your-api-key-here", // Your API key
+  "X-API-Key", // Header name (optional)
+)
+```
+
+**Features**:
+
+- API key validation
+- Custom header names
+- Clear error messages
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Choose an authentication example:
+
+   - Edit `src/index.ts` and uncomment the example you want to try
+   - Update the configuration with your API details
+
+3. Build the project:
+
+```bash
+npm run build
+```
+
+4. Run the server:
+
+```bash
+npm start
+```
+
+## Configuration
+
+Each AuthProvider example shows different configuration patterns:
+
+### Refreshable Token Example
+
+```typescript
+const authProvider = new RefreshableAuthProvider(
+  "https://api.example.com/oauth/token",
+  "initial-access-token",
+  "initial-refresh-token",
+)
+
+const config = {
+  // ... other config
+  authProvider: authProvider,
+}
+```
+
+### Manual Token Example
+
+```typescript
+const authProvider = new ManualTokenAuthProvider("MyAPI")
+authProvider.updateToken("your-token", 3600)
+
+const config = {
+  // ... other config
+  authProvider: authProvider,
+}
+```
+
+### API Key Example
+
+```typescript
+const authProvider = new ApiKeyAuthProvider("your-api-key", "X-API-Key")
+
+const config = {
+  // ... other config
+  authProvider: authProvider,
+}
+```
+
+## Key Benefits
+
+### 1. Dynamic Authentication
+
+- Headers are fetched fresh for each request
+- Tokens can be validated before sending requests
+- Supports runtime token updates
+
+### 2. Error Handling
+
+- Automatic detection of authentication errors (401/403)
+- Custom error messages with actionable instructions
+- Retry logic for recoverable errors
+
+### 3. Flexibility
+
+- Implement any authentication pattern
+- Support for multiple authentication methods
+- Easy to extend for custom requirements
+
+## Real-World Usage
+
+### Beatport-style Manual Token Management
+
+```typescript
+class BeatportAuthProvider extends ManualTokenAuthProvider {
+  constructor() {
+    super("Beatport")
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    throw new Error(
+      "Beatport authentication failed. To get a new token:\n" +
+        "1. Go to https://www.beatport.com\n" +
+        "2. Log in to your account\n" +
+        "3. Open browser dev tools (F12)\n" +
+        "4. Go to Network tab\n" +
+        "5. Make any API request\n" +
+        "6. Copy the Authorization header\n" +
+        "7. Update your token using updateToken()",
+    )
+  }
+}
+```
+
+### OAuth2 with Automatic Refresh
+
+```typescript
+class OAuth2AuthProvider extends RefreshableAuthProvider {
+  constructor(clientId: string, clientSecret: string) {
+    super("https://api.example.com/oauth/token")
+    this.clientId = clientId
+    this.clientSecret = clientSecret
+  }
+
+  // Override refresh logic for your specific OAuth2 implementation
+  private async refreshAccessToken(): Promise<void> {
+    // Custom OAuth2 refresh implementation
+  }
+}
+```
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "my-auth-api": {
+      "command": "node",
+      "args": ["/path/to/auth-provider-example/dist/index.js"]
+    }
+  }
+}
+```
+
+## Next Steps
+
+- See the `beatport-example` for a complete real-world implementation
+- Check the main documentation for more AuthProvider patterns
+- Implement your own custom AuthProvider for your specific API

--- a/examples/auth-provider-example/package.json
+++ b/examples/auth-provider-example/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "auth-provider-mcp-example",
+  "version": "1.0.0",
+  "description": "Example showing AuthProvider usage with mcp-openapi-server",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@ivotoby/openapi-mcp-server": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "axios": "^1.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/examples/auth-provider-example/src/auth-provider.ts
+++ b/examples/auth-provider-example/src/auth-provider.ts
@@ -1,0 +1,220 @@
+import { AuthProvider } from "@ivotoby/openapi-mcp-server"
+import { AxiosError } from "axios"
+
+/**
+ * Example AuthProvider that handles token expiration and refresh
+ * This demonstrates automatic token refresh capabilities
+ */
+export class RefreshableAuthProvider implements AuthProvider {
+  private accessToken: string | null = null
+  private refreshToken: string | null = null
+  private tokenExpiry: Date | null = null
+  private refreshUrl: string
+
+  constructor(refreshUrl: string, initialAccessToken?: string, initialRefreshToken?: string) {
+    this.refreshUrl = refreshUrl
+    this.accessToken = initialAccessToken || null
+    this.refreshToken = initialRefreshToken || null
+  }
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    // Check if token is expired or about to expire (1 minute buffer)
+    if (!this.accessToken || this.isTokenExpired()) {
+      if (this.refreshToken) {
+        await this.refreshAccessToken()
+      } else {
+        throw new Error(
+          "Access token expired and no refresh token available. Please re-authenticate.",
+        )
+      }
+    }
+
+    return {
+      Authorization: `Bearer ${this.accessToken}`,
+      "Content-Type": "application/json",
+    }
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    // If we get a 401/403, try to refresh the token
+    if ((error.response?.status === 401 || error.response?.status === 403) && this.refreshToken) {
+      try {
+        await this.refreshAccessToken()
+        return true // Retry the request with new token
+      } catch (refreshError) {
+        throw new Error(
+          "Failed to refresh access token. Please re-authenticate with your credentials.",
+        )
+      }
+    }
+
+    return false // Don't retry for other errors
+  }
+
+  /**
+   * Set initial tokens
+   */
+  setTokens(accessToken: string, refreshToken: string, expiresIn: number = 3600): void {
+    this.accessToken = accessToken
+    this.refreshToken = refreshToken
+    this.tokenExpiry = new Date(Date.now() + expiresIn * 1000)
+  }
+
+  /**
+   * Check if the current token is expired (with 1 minute buffer)
+   */
+  private isTokenExpired(): boolean {
+    if (!this.tokenExpiry) return true
+    return this.tokenExpiry <= new Date(Date.now() + 60000) // 1 minute buffer
+  }
+
+  /**
+   * Refresh the access token using the refresh token
+   */
+  private async refreshAccessToken(): Promise<void> {
+    if (!this.refreshToken) {
+      throw new Error("No refresh token available")
+    }
+
+    // This is a mock implementation - replace with your actual refresh logic
+    const response = await fetch(this.refreshUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        refresh_token: this.refreshToken,
+        grant_type: "refresh_token",
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Token refresh failed: ${response.status} ${response.statusText}`)
+    }
+
+    const data = await response.json()
+    this.accessToken = data.access_token
+    this.refreshToken = data.refresh_token || this.refreshToken
+    this.tokenExpiry = new Date(Date.now() + (data.expires_in || 3600) * 1000)
+  }
+}
+
+/**
+ * Example AuthProvider for APIs that require manual token updates
+ * This is useful for APIs like Beatport where automatic refresh isn't possible
+ */
+export class ManualTokenAuthProvider implements AuthProvider {
+  private token: string | null = null
+  private tokenExpiry: Date | null = null
+  private apiName: string
+
+  constructor(apiName: string = "API") {
+    this.apiName = apiName
+  }
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    if (!this.token || this.isTokenExpired()) {
+      throw new Error(
+        `${this.apiName} token expired or not set. Please update your token using the updateToken method.`,
+      )
+    }
+
+    return {
+      Authorization: `Bearer ${this.token}`,
+      "User-Agent": `${this.apiName}-MCP-Server/1.0.0`,
+    }
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    // For manual token management, we can't auto-retry
+    // Provide helpful error message instead
+    const statusCode = error.response?.status
+    if (statusCode === 401 || statusCode === 403) {
+      throw new Error(
+        `${this.apiName} authentication failed (${statusCode}). Your token may be expired or invalid.\n\n` +
+          "To get a new token:\n" +
+          `1. Visit the ${this.apiName} website and log in\n` +
+          "2. Open browser developer tools (F12)\n" +
+          "3. Go to Network tab and make an API request\n" +
+          "4. Copy the Authorization header value\n" +
+          "5. Update your token using the updateToken method",
+      )
+    }
+
+    return false // Never retry for manual token management
+  }
+
+  /**
+   * Update the token manually
+   */
+  updateToken(token: string, expiresIn: number = 3600): void {
+    // Remove 'Bearer ' prefix if present
+    this.token = token.replace(/^Bearer\s+/i, "")
+    this.tokenExpiry = new Date(Date.now() + expiresIn * 1000)
+    console.error(`✅ ${this.apiName} token updated successfully`)
+  }
+
+  /**
+   * Check if token is expired (with 5 minute buffer for manual tokens)
+   */
+  private isTokenExpired(): boolean {
+    if (!this.tokenExpiry) return true
+    return this.tokenExpiry <= new Date(Date.now() + 300000) // 5 minute buffer
+  }
+
+  /**
+   * Get token status for debugging
+   */
+  getTokenStatus(): { hasToken: boolean; isExpired: boolean; expiresAt: Date | null } {
+    return {
+      hasToken: !!this.token,
+      isExpired: this.isTokenExpired(),
+      expiresAt: this.tokenExpiry,
+    }
+  }
+}
+
+/**
+ * Example AuthProvider for API key authentication
+ * This is for APIs that use API keys instead of bearer tokens
+ */
+export class ApiKeyAuthProvider implements AuthProvider {
+  private apiKey: string
+  private keyHeader: string
+
+  constructor(apiKey: string, keyHeader: string = "X-API-Key") {
+    this.apiKey = apiKey
+    this.keyHeader = keyHeader
+  }
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    if (!this.apiKey) {
+      throw new Error("API key is required but not set")
+    }
+
+    return {
+      [this.keyHeader]: this.apiKey,
+      "Content-Type": "application/json",
+    }
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    // API keys typically don't expire, so auth errors are usually permanent
+    const statusCode = error.response?.status
+    if (statusCode === 401 || statusCode === 403) {
+      throw new Error(
+        `API key authentication failed (${statusCode}). Please check that your API key is valid and has the required permissions.`,
+      )
+    }
+
+    return false
+  }
+
+  /**
+   * Update the API key
+   */
+  updateApiKey(newApiKey: string): void {
+    this.apiKey = newApiKey
+    console.error("✅ API key updated successfully")
+  }
+}

--- a/examples/auth-provider-example/src/index.ts
+++ b/examples/auth-provider-example/src/index.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { OpenAPIServer } from "@ivotoby/openapi-mcp-server"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import {
+  RefreshableAuthProvider,
+  ManualTokenAuthProvider,
+  ApiKeyAuthProvider,
+} from "./auth-provider.js"
+
+/**
+ * Example showing different AuthProvider implementations
+ * Uncomment the example you want to try
+ */
+async function main(): Promise<void> {
+  try {
+    // Example 1: Refreshable Token Authentication
+    // Uncomment this section to use automatic token refresh
+    /*
+    const authProvider = new RefreshableAuthProvider(
+      'https://api.example.com/oauth/token', // Token refresh URL
+      'initial-access-token',                // Initial access token
+      'initial-refresh-token'                // Initial refresh token
+    )
+    */
+
+    // Example 2: Manual Token Management (like Beatport)
+    // Uncomment this section for manual token updates
+    /*
+    const authProvider = new ManualTokenAuthProvider('MyAPI')
+    // Set initial token (you would get this from user input or config)
+    authProvider.updateToken('your-bearer-token-here', 3600)
+    */
+
+    // Example 3: API Key Authentication
+    // Uncomment this section for API key auth
+    const authProvider = new ApiKeyAuthProvider(
+      "your-api-key-here", // Your API key
+      "X-API-Key", // Header name (optional, defaults to X-API-Key)
+    )
+
+    const config = {
+      name: "auth-provider-example",
+      version: "1.0.0",
+      apiBaseUrl: "https://api.example.com",
+      openApiSpec: "https://api.example.com/openapi.json",
+      specInputMethod: "url" as const,
+      authProvider: authProvider, // Use AuthProvider instead of static headers
+      transportType: "stdio" as const,
+      toolsMode: "all" as const,
+    }
+
+    // Create and start the server
+    const server = new OpenAPIServer(config)
+    const transport = new StdioServerTransport()
+
+    await server.start(transport)
+    console.error("AuthProvider Example MCP Server running on stdio")
+  } catch (error) {
+    console.error("Failed to start server:", error)
+    process.exit(1)
+  }
+}
+
+// Run the server
+main()

--- a/examples/auth-provider-example/tsconfig.json
+++ b/examples/auth-provider-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/basic-library-usage/README.md
+++ b/examples/basic-library-usage/README.md
@@ -1,0 +1,71 @@
+# Basic Library Usage Example
+
+This example demonstrates how to use `@ivotoby/openapi-mcp-server` as a library to create a dedicated MCP server for a specific API.
+
+## Overview
+
+Instead of using the CLI tool directly, you can import and use the `OpenAPIServer` class in your own Node.js application. This approach is useful when you want to:
+
+- Create a dedicated package for a specific API
+- Add custom logic or middleware
+- Bundle the server with your application
+- Customize the server behavior
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Update the configuration in `src/index.ts`:
+
+   - Replace `https://api.example.com` with your API's base URL
+   - Replace `https://api.example.com/openapi.json` with your OpenAPI spec URL
+   - Update the headers with your API credentials
+
+3. Build the project:
+
+```bash
+npm run build
+```
+
+4. Run the server:
+
+```bash
+npm start
+```
+
+## Configuration
+
+The server is configured in `src/index.ts`. Key configuration options:
+
+- `name`: Name of your MCP server
+- `version`: Version of your server
+- `apiBaseUrl`: Base URL for your API
+- `openApiSpec`: URL or path to your OpenAPI specification
+- `headers`: Static authentication headers
+- `transportType`: Use 'stdio' for Claude Desktop integration
+- `toolsMode`: Use 'all' to load all endpoints as tools
+
+## Usage with Claude Desktop
+
+To use this server with Claude Desktop, add it to your configuration:
+
+```json
+{
+  "mcpServers": {
+    "my-api": {
+      "command": "node",
+      "args": ["/path/to/your/project/dist/index.js"]
+    }
+  }
+}
+```
+
+## Next Steps
+
+- See the `auth-provider-example` for dynamic authentication
+- See the `beatport-example` for a real-world implementation
+- Check the main README for more configuration options

--- a/examples/basic-library-usage/package.json
+++ b/examples/basic-library-usage/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "my-api-mcp-server",
+  "version": "1.0.0",
+  "description": "Custom MCP server for My API using mcp-openapi-server",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@ivotoby/openapi-mcp-server": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/examples/basic-library-usage/src/index.ts
+++ b/examples/basic-library-usage/src/index.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { OpenAPIServer } from "@ivotoby/openapi-mcp-server"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+
+/**
+ * Basic example of using mcp-openapi-server as a library
+ * This creates a dedicated MCP server for a specific API
+ */
+async function main(): Promise<void> {
+  try {
+    // Configure your API server
+    const config = {
+      name: "my-api-mcp-server",
+      version: "1.0.0",
+      apiBaseUrl: "https://api.example.com",
+      openApiSpec: "https://api.example.com/openapi.json",
+      specInputMethod: "url" as const,
+      headers: {
+        Authorization: "Bearer your-api-token",
+        "X-API-Key": "your-api-key",
+        "User-Agent": "MyApp/1.0.0",
+      },
+      transportType: "stdio" as const,
+      toolsMode: "all" as const,
+    }
+
+    // Create and start the server
+    const server = new OpenAPIServer(config)
+    const transport = new StdioServerTransport()
+
+    await server.start(transport)
+    console.error("My API MCP Server running on stdio")
+  } catch (error) {
+    console.error("Failed to start server:", error)
+    process.exit(1)
+  }
+}
+
+// Run the server
+main()

--- a/examples/basic-library-usage/tsconfig.json
+++ b/examples/basic-library-usage/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/beatport-example/README.md
+++ b/examples/beatport-example/README.md
@@ -1,0 +1,254 @@
+# Beatport MCP Server
+
+A dedicated MCP server for the Beatport API, built using `@ivotoby/openapi-mcp-server` with custom authentication handling.
+
+## Overview
+
+This example demonstrates a real-world implementation of a dedicated MCP server for a specific API (Beatport). It showcases:
+
+- **Custom AuthProvider**: Handles Beatport's manual token requirements
+- **API Filtering**: Only exposes relevant endpoints (tracks, artists, etc.)
+- **Error Handling**: Provides clear instructions for token renewal
+- **Production Ready**: Can be packaged and distributed as a standalone tool
+
+## Features
+
+### 🎵 Beatport API Integration
+
+- Search tracks, artists, labels, and releases
+- Browse genres and charts
+- Access detailed track information
+- Filter and sort results
+
+### 🔐 Smart Authentication
+
+- Manual token management (required for Beatport)
+- Clear error messages with step-by-step token renewal instructions
+- Token expiry tracking with warnings
+- Automatic token validation before requests
+
+### 🛠️ Optimized Configuration
+
+- Only loads relevant endpoints (no admin/write operations)
+- Focuses on catalog browsing and search functionality
+- Efficient tool loading with filtering
+
+## Setup
+
+### 1. Install Dependencies
+
+```bash
+npm install
+```
+
+### 2. Get a Beatport Token
+
+Since Beatport doesn't provide public OAuth2, you need to extract a token from your browser:
+
+1. Go to [Beatport.com](https://www.beatport.com) and log in
+2. Open browser developer tools (F12)
+3. Go to the **Network** tab
+4. Search for a track or browse the catalog
+5. Look for requests to `api.beatport.com` in the Network tab
+6. Click on any API request
+7. In the **Headers** section, find the `Authorization` header
+8. Copy the full value (starts with `Bearer `)
+
+### 3. Set Your Token (Optional)
+
+You can provide an initial token via environment variable:
+
+```bash
+export BEATPORT_TOKEN="your-bearer-token-here"
+```
+
+### 4. Build and Run
+
+```bash
+npm run build
+npm start
+```
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "beatport": {
+      "command": "node",
+      "args": ["/path/to/beatport-example/dist/index.js"],
+      "env": {
+        "BEATPORT_TOKEN": "your-bearer-token-here"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+The server exposes Beatport API endpoints as MCP tools:
+
+### Search & Discovery
+
+- `GET-search-tracks` - Search for tracks
+- `GET-search-artists` - Search for artists
+- `GET-search-labels` - Search for labels
+- `GET-search-releases` - Search for releases
+
+### Browse Catalog
+
+- `GET-tracks` - Browse tracks with filters
+- `GET-artists` - Browse artists
+- `GET-labels` - Browse labels
+- `GET-releases` - Browse releases
+- `GET-genres` - Get available genres
+
+### Detailed Information
+
+- `GET-tracks-{id}` - Get detailed track information
+- `GET-artists-{id}` - Get detailed artist information
+- `GET-labels-{id}` - Get detailed label information
+- `GET-releases-{id}` - Get detailed release information
+
+## Token Management
+
+### Updating Tokens
+
+When your token expires, you'll get a clear error message with instructions. The AuthProvider handles this gracefully and provides step-by-step guidance.
+
+### Token Status
+
+The server logs token status on startup:
+
+```
+🎵 Beatport MCP Server running on stdio
+   Ready to search tracks, artists, and more!
+   Token status: Valid
+   Time until expiry: 2h 45m
+```
+
+### Manual Token Updates
+
+If you need to update the token while the server is running, you would need to restart with a new token (or implement a custom tool for runtime updates).
+
+## Example Queries
+
+Once connected to Claude Desktop, you can ask:
+
+- "Search for techno tracks on Beatport"
+- "Find artists similar to Charlotte de Witte"
+- "What are the top releases this week?"
+- "Show me tracks in the Progressive House genre"
+- "Get details for track ID 12345"
+
+## Architecture
+
+### BeatportAuthProvider
+
+Custom AuthProvider implementation that:
+
+- Manages manual token updates
+- Provides detailed error messages for token issues
+- Tracks token expiry with buffer time
+- Handles 401/403 errors gracefully
+
+### Configuration
+
+Optimized for Beatport's catalog API:
+
+- Filters to only GET/POST operations
+- Focuses on catalog endpoints (tracks, artists, etc.)
+- Uses Beatport's OpenAPI specification
+
+### Error Handling
+
+Comprehensive error handling for:
+
+- Expired tokens
+- Invalid tokens
+- Network issues
+- API rate limits
+
+## Packaging for Distribution
+
+This example can be packaged as a standalone npm package:
+
+1. Update `package.json` with your details
+2. Build the project: `npm run build`
+3. Publish: `npm publish`
+
+Users can then install and use it directly:
+
+```bash
+npx your-beatport-mcp-server
+```
+
+## Extending the Example
+
+### Adding Custom Tools
+
+You can extend the server with custom tools for:
+
+- Playlist management
+- Favorite tracks
+- Purchase history
+- Custom search filters
+
+### Runtime Token Updates
+
+Implement a custom tool that allows token updates without restart:
+
+```typescript
+// Add to your server configuration
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name === "update-token") {
+    const { token } = request.params.arguments
+    authProvider.updateToken(token)
+    return { content: [{ type: "text", text: "Token updated successfully" }] }
+  }
+  // ... handle other tools
+})
+```
+
+## Security Considerations
+
+- Never commit tokens to version control
+- Use environment variables for token storage
+- Tokens should be treated as sensitive credentials
+- Consider implementing token encryption for production use
+
+## Troubleshooting
+
+### Common Issues
+
+**"Token expired or not set"**
+
+- Get a fresh token from your browser
+- Make sure you copied the full Authorization header
+- Check that the token starts with "Bearer "
+
+**"Authentication failed (401)"**
+
+- Your token has expired, get a new one
+- Make sure you're logged in to Beatport
+- Verify the token was copied correctly
+
+**"Authentication failed (403)"**
+
+- Your account may not have API access
+- Try logging out and back in to Beatport
+- Ensure your account is in good standing
+
+**"Cannot find module '@ivotoby/openapi-mcp-server'"**
+
+- Run `npm install` to install dependencies
+- Make sure you're using the correct package version
+
+## Next Steps
+
+- Explore the other examples for different patterns
+- Check the main documentation for more configuration options
+- Consider contributing improvements back to the project

--- a/examples/beatport-example/package.json
+++ b/examples/beatport-example/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "beatport-mcp-server",
+  "version": "1.0.0",
+  "description": "Beatport API MCP server using mcp-openapi-server",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "beatport-mcp-server": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@ivotoby/openapi-mcp-server": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "axios": "^1.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0"
+  },
+  "keywords": [
+    "beatport",
+    "mcp",
+    "music",
+    "api",
+    "claude"
+  ]
+}

--- a/examples/beatport-example/src/beatport-auth.ts
+++ b/examples/beatport-example/src/beatport-auth.ts
@@ -1,0 +1,152 @@
+import { AuthProvider } from "@ivotoby/openapi-mcp-server"
+import { AxiosError } from "axios"
+
+/**
+ * Beatport-specific AuthProvider that handles manual token management
+ *
+ * Beatport requires manual token extraction from browser sessions
+ * since they don't provide a public OAuth2 refresh mechanism
+ */
+export class BeatportAuthProvider implements AuthProvider {
+  private token: string | null = null
+  private tokenExpiry: Date | null = null
+
+  constructor(initialToken?: string) {
+    if (initialToken) {
+      this.updateToken(initialToken)
+    }
+  }
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    if (!this.token || this.isTokenExpired()) {
+      throw new Error(
+        "Beatport token expired or not set. Please update your token using the updateToken method.\n\n" +
+          "To get a new token:\n" +
+          "1. Go to https://www.beatport.com and log in\n" +
+          "2. Open browser developer tools (F12)\n" +
+          "3. Go to the Network tab\n" +
+          "4. Make any API request (search for tracks, etc.)\n" +
+          "5. Find a request to api.beatport.com\n" +
+          "6. Copy the Authorization header value\n" +
+          "7. Call updateToken() with the new token",
+      )
+    }
+
+    return {
+      Authorization: `Bearer ${this.token}`,
+      "User-Agent": "Beatport-MCP-Server/1.0.0",
+      Accept: "application/json",
+    }
+  }
+
+  async handleAuthError(error: AxiosError): Promise<boolean> {
+    const statusCode = error.response?.status
+
+    if (statusCode === 401) {
+      throw new Error(
+        "Beatport authentication failed (401 Unauthorized). Your token has expired.\n\n" +
+          "To get a new token:\n" +
+          "1. Go to https://www.beatport.com and log in\n" +
+          "2. Open browser developer tools (F12)\n" +
+          "3. Go to the Network tab\n" +
+          "4. Search for a track or browse the catalog\n" +
+          "5. Look for requests to api.beatport.com in the Network tab\n" +
+          "6. Click on any API request\n" +
+          '7. In the Headers section, find the "Authorization" header\n' +
+          '8. Copy the full value (should start with "Bearer ")\n' +
+          "9. Update your token using the updateToken command",
+      )
+    }
+
+    if (statusCode === 403) {
+      throw new Error(
+        "Beatport authentication failed (403 Forbidden). Your token may be invalid or you may not have permission to access this resource.\n\n" +
+          "Please ensure:\n" +
+          "1. You are logged in to Beatport\n" +
+          "2. Your account has the necessary permissions\n" +
+          "3. Your token is valid and not expired\n" +
+          "4. Try getting a fresh token from your browser",
+      )
+    }
+
+    // Don't retry for manual token management
+    return false
+  }
+
+  /**
+   * Update the Beatport token manually
+   *
+   * @param token - The bearer token (with or without "Bearer " prefix)
+   * @param expiresIn - Token expiry time in seconds (default: 1 hour)
+   */
+  updateToken(token: string, expiresIn: number = 3600): void {
+    // Remove 'Bearer ' prefix if present
+    this.token = token.replace(/^Bearer\s+/i, "")
+
+    // Set expiry with a 5-minute buffer for manual tokens
+    this.tokenExpiry = new Date(Date.now() + expiresIn * 1000)
+
+    console.error("✅ Beatport token updated successfully")
+    console.error(`   Token expires at: ${this.tokenExpiry.toISOString()}`)
+  }
+
+  /**
+   * Check if the current token is expired
+   * Uses a 5-minute buffer to warn before actual expiry
+   */
+  private isTokenExpired(): boolean {
+    if (!this.tokenExpiry) return true
+
+    // 5-minute buffer for manual tokens
+    const bufferTime = 5 * 60 * 1000
+    return this.tokenExpiry <= new Date(Date.now() + bufferTime)
+  }
+
+  /**
+   * Get current token status for debugging
+   */
+  getTokenStatus(): {
+    hasToken: boolean
+    isExpired: boolean
+    expiresAt: Date | null
+    timeUntilExpiry: string | null
+  } {
+    const hasToken = !!this.token
+    const isExpired = this.isTokenExpired()
+    const expiresAt = this.tokenExpiry
+
+    let timeUntilExpiry: string | null = null
+    if (expiresAt) {
+      const msUntilExpiry = expiresAt.getTime() - Date.now()
+      if (msUntilExpiry > 0) {
+        const minutes = Math.floor(msUntilExpiry / (1000 * 60))
+        const hours = Math.floor(minutes / 60)
+        const remainingMinutes = minutes % 60
+
+        if (hours > 0) {
+          timeUntilExpiry = `${hours}h ${remainingMinutes}m`
+        } else {
+          timeUntilExpiry = `${remainingMinutes}m`
+        }
+      } else {
+        timeUntilExpiry = "Expired"
+      }
+    }
+
+    return {
+      hasToken,
+      isExpired,
+      expiresAt,
+      timeUntilExpiry,
+    }
+  }
+
+  /**
+   * Clear the current token
+   */
+  clearToken(): void {
+    this.token = null
+    this.tokenExpiry = null
+    console.error("🗑️  Beatport token cleared")
+  }
+}

--- a/examples/beatport-example/src/index.ts
+++ b/examples/beatport-example/src/index.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { OpenAPIServer } from "@ivotoby/openapi-mcp-server"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { BeatportAuthProvider } from "./beatport-auth.js"
+
+/**
+ * Beatport MCP Server
+ *
+ * A dedicated MCP server for the Beatport API using mcp-openapi-server
+ * with custom authentication handling for Beatport's token requirements
+ */
+async function main(): Promise<void> {
+  try {
+    // Create Beatport auth provider
+    const authProvider = new BeatportAuthProvider()
+
+    // You can set an initial token from environment variable
+    const initialToken = process.env.BEATPORT_TOKEN
+    if (initialToken) {
+      authProvider.updateToken(initialToken)
+      console.error("🎵 Using Beatport token from environment variable")
+    } else {
+      console.error("⚠️  No initial Beatport token provided")
+      console.error("   You will need to update the token manually after starting")
+    }
+
+    const config = {
+      name: "beatport-mcp-server",
+      version: "1.0.0",
+      apiBaseUrl: "https://api.beatport.com",
+      openApiSpec: "https://api.beatport.com/v4/catalog/openapi.json",
+      specInputMethod: "url" as const,
+      authProvider: authProvider,
+      transportType: "stdio" as const,
+      toolsMode: "all" as const,
+      // Filter to only include useful endpoints
+      includeOperations: ["get", "post"],
+      // Focus on catalog endpoints
+      includeResources: ["tracks", "artists", "labels", "releases", "genres", "search"],
+    }
+
+    // Create and start the server
+    const server = new OpenAPIServer(config)
+    const transport = new StdioServerTransport()
+
+    await server.start(transport)
+    console.error("🎵 Beatport MCP Server running on stdio")
+    console.error("   Ready to search tracks, artists, and more!")
+
+    // Log token status
+    const tokenStatus = authProvider.getTokenStatus()
+    if (tokenStatus.hasToken) {
+      console.error(`   Token status: ${tokenStatus.isExpired ? "Expired" : "Valid"}`)
+      if (tokenStatus.timeUntilExpiry) {
+        console.error(`   Time until expiry: ${tokenStatus.timeUntilExpiry}`)
+      }
+    }
+  } catch (error) {
+    console.error("Failed to start Beatport MCP server:", error)
+    process.exit(1)
+  }
+}
+
+// Run the server
+main()

--- a/examples/beatport-example/tsconfig.json
+++ b/examples/beatport-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/scripts/test-auth-provider.js
+++ b/scripts/test-auth-provider.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+// Test script to verify AuthProvider implementation
+
+import { ApiClient } from '../src/api-client.js'
+import { AuthProvider, StaticAuthProvider } from '../src/auth-provider.js'
+
+console.log('🧪 Testing AuthProvider implementation...')
+
+// Test 1: StaticAuthProvider
+console.log('\n1. Testing StaticAuthProvider...')
+const staticAuth = new StaticAuthProvider({ 'Authorization': 'Bearer test-token' })
+
+staticAuth.getAuthHeaders().then(headers => {
+  console.log('✅ StaticAuthProvider headers:', headers)
+}).catch(err => {
+  console.log('❌ StaticAuthProvider error:', err)
+})
+
+// Test 2: Custom AuthProvider
+console.log('\n2. Testing Custom AuthProvider...')
+class TestAuthProvider {
+  constructor() {
+    this.tokenValid = true
+    this.callCount = 0
+  }
+
+  async getAuthHeaders() {
+    this.callCount++
+    if (!this.tokenValid) {
+      throw new Error('Token expired')
+    }
+    return { 'Authorization': `Bearer fresh-token-${this.callCount}` }
+  }
+
+  async handleAuthError(error) {
+    console.log('🔄 Handling auth error:', error.response?.status)
+    if (this.callCount === 1) {
+      // First error, refresh token
+      this.tokenValid = true
+      return true // retry
+    }
+    // Second error, give up
+    return false
+  }
+
+  expireToken() {
+    this.tokenValid = false
+  }
+}
+
+const customAuth = new TestAuthProvider()
+
+customAuth.getAuthHeaders().then(headers => {
+  console.log('✅ Custom AuthProvider headers:', headers)
+}).catch(err => {
+  console.log('❌ Custom AuthProvider error:', err)
+})
+
+// Test 3: ApiClient with AuthProvider
+console.log('\n3. Testing ApiClient with AuthProvider...')
+const apiClient = new ApiClient('https://api.example.com', customAuth)
+
+console.log('✅ ApiClient created with AuthProvider')
+
+// Test 4: Backward compatibility
+console.log('\n4. Testing backward compatibility...')
+const legacyClient = new ApiClient('https://api.example.com', { 'X-API-Key': 'legacy-key' })
+
+console.log('✅ ApiClient created with legacy headers')
+
+console.log('\n🎉 All tests completed!')

--- a/src/auth-provider.ts
+++ b/src/auth-provider.ts
@@ -1,0 +1,52 @@
+import { AxiosError } from "axios"
+
+/**
+ * Interface for providing authentication headers and handling authentication errors
+ */
+export interface AuthProvider {
+  /**
+   * Get authentication headers for the current request
+   * This method is called before each API request to get fresh headers
+   *
+   * @returns Promise that resolves to headers object
+   * @throws Error if authentication is not available (e.g., token expired)
+   */
+  getAuthHeaders(): Promise<Record<string, string>>
+
+  /**
+   * Handle authentication errors from API responses
+   * This is called when the API returns authentication-related errors (401, 403)
+   *
+   * @param error - The axios error from the failed request
+   * @returns Promise that resolves to true if the request should be retried, false otherwise
+   */
+  handleAuthError(error: AxiosError): Promise<boolean>
+}
+
+/**
+ * Check if an error is authentication-related
+ *
+ * @param error - The error to check
+ * @returns true if the error is authentication-related
+ */
+export function isAuthError(error: AxiosError): boolean {
+  return error.response?.status === 401 || error.response?.status === 403
+}
+
+/**
+ * Simple AuthProvider implementation that uses static headers
+ * This is used for backward compatibility when no AuthProvider is provided
+ */
+export class StaticAuthProvider implements AuthProvider {
+  constructor(private headers: Record<string, string> = {}) {}
+
+  async getAuthHeaders(): Promise<Record<string, string>> {
+    return { ...this.headers }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async handleAuthError(_error: AxiosError): Promise<boolean> {
+    // Static auth provider cannot handle auth errors
+    return false
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { main } from "./index.js"
+
+// CLI entry point - just calls main()
+main()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { main } from "./index.js"
 
 // CLI entry point - just calls main()

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
+import { AuthProvider } from "./auth-provider.js"
 
 export interface OpenAPIMCPServerConfig {
   name: string
@@ -11,6 +12,8 @@ export interface OpenAPIMCPServerConfig {
   /** Inline spec content when using 'inline' method */
   inlineSpecContent?: string
   headers?: Record<string, string>
+  /** AuthProvider for dynamic authentication (takes precedence over headers) */
+  authProvider?: AuthProvider
   transportType: "stdio" | "http"
   httpPort?: number
   httpHost?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "./config"
 import { StreamableHttpServerTransport } from "./transport/StreamableHttpServerTransport"
 
 /**
- * Main entry point
+ * Main entry point for CLI usage
  */
 async function main(): Promise<void> {
   try {
@@ -38,8 +38,10 @@ async function main(): Promise<void> {
   }
 }
 
-// Start the server
-main()
+// Only run main() if this file is executed directly (not imported)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}
 
 // Re-export important classes for library usage
 export * from "./server"
@@ -48,3 +50,6 @@ export * from "./config"
 export * from "./tools-manager"
 export * from "./openapi-loader"
 export * from "./transport/StreamableHttpServerTransport"
+
+// Export the main function for programmatic usage
+export { main }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from "./api-client"
 export * from "./config"
 export * from "./tools-manager"
 export * from "./openapi-loader"
+export * from "./auth-provider"
 export * from "./transport/StreamableHttpServerTransport"
 
 // Export the main function for programmatic usage

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { OpenAPIMCPServerConfig } from "./config"
 import { ToolsManager } from "./tools-manager"
 import { ApiClient } from "./api-client"
 import { Tool } from "@modelcontextprotocol/sdk/types.js"
+import { StaticAuthProvider } from "./auth-provider.js"
 
 /**
  * MCP server implementation for OpenAPI specifications
@@ -27,7 +28,11 @@ export class OpenAPIServer {
       },
     )
     this.toolsManager = new ToolsManager(config)
-    this.apiClient = new ApiClient(config.apiBaseUrl, config.headers)
+
+    // Use AuthProvider if provided, otherwise fallback to static headers
+    const authProviderOrHeaders = config.authProvider || new StaticAuthProvider(config.headers)
+    this.apiClient = new ApiClient(config.apiBaseUrl, authProviderOrHeaders)
+
     this.initializeHandlers()
   }
 

--- a/test/auth-provider.test.ts
+++ b/test/auth-provider.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from "vitest"
+import { AxiosError } from "axios"
+import { AuthProvider, StaticAuthProvider, isAuthError } from "../src/auth-provider"
+
+describe("AuthProvider", () => {
+  describe("isAuthError", () => {
+    it("should return true for 401 errors", () => {
+      const error = {
+        response: { status: 401 },
+      } as AxiosError
+
+      expect(isAuthError(error)).toBe(true)
+    })
+
+    it("should return true for 403 errors", () => {
+      const error = {
+        response: { status: 403 },
+      } as AxiosError
+
+      expect(isAuthError(error)).toBe(true)
+    })
+
+    it("should return false for other error statuses", () => {
+      const error404 = {
+        response: { status: 404 },
+      } as AxiosError
+
+      const error500 = {
+        response: { status: 500 },
+      } as AxiosError
+
+      expect(isAuthError(error404)).toBe(false)
+      expect(isAuthError(error500)).toBe(false)
+    })
+
+    it("should return false for errors without response", () => {
+      const error = {} as AxiosError
+      expect(isAuthError(error)).toBe(false)
+    })
+  })
+
+  describe("StaticAuthProvider", () => {
+    it("should return provided headers", async () => {
+      const headers = { Authorization: "Bearer token123", "X-API-Key": "key456" }
+      const provider = new StaticAuthProvider(headers)
+
+      const result = await provider.getAuthHeaders()
+      expect(result).toEqual(headers)
+    })
+
+    it("should return empty object when no headers provided", async () => {
+      const provider = new StaticAuthProvider()
+
+      const result = await provider.getAuthHeaders()
+      expect(result).toEqual({})
+    })
+
+    it("should return copy of headers (not reference)", async () => {
+      const headers = { Authorization: "Bearer token123" }
+      const provider = new StaticAuthProvider(headers)
+
+      const result = await provider.getAuthHeaders()
+      result["X-Modified"] = "test"
+
+      const result2 = await provider.getAuthHeaders()
+      expect(result2).toEqual(headers)
+      expect(result2).not.toHaveProperty("X-Modified")
+    })
+
+    it("should always return false for handleAuthError", async () => {
+      const provider = new StaticAuthProvider()
+      const error = { response: { status: 401 } } as AxiosError
+
+      const result = await provider.handleAuthError(error)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("Custom AuthProvider Implementation", () => {
+    class MockAuthProvider implements AuthProvider {
+      private isValid = true
+      private retryCount = 0
+
+      async getAuthHeaders(): Promise<Record<string, string>> {
+        if (!this.isValid) {
+          throw new Error("Token expired")
+        }
+        return { Authorization: "Bearer valid-token" }
+      }
+
+      async handleAuthError(_error: AxiosError): Promise<boolean> {
+        this.retryCount++
+        if (this.retryCount === 1) {
+          // First auth error - refresh token and retry
+          this.isValid = true
+          return true
+        }
+        // Second auth error - give up
+        return false
+      }
+
+      // Test helper methods
+      expireToken() {
+        this.isValid = false
+      }
+
+      getRetryCount() {
+        return this.retryCount
+      }
+    }
+
+    it("should provide valid headers when token is valid", async () => {
+      const provider = new MockAuthProvider()
+
+      const headers = await provider.getAuthHeaders()
+      expect(headers).toEqual({ Authorization: "Bearer valid-token" })
+    })
+
+    it("should throw error when token is expired", async () => {
+      const provider = new MockAuthProvider()
+      provider.expireToken()
+
+      await expect(provider.getAuthHeaders()).rejects.toThrow("Token expired")
+    })
+
+    it("should handle auth errors with retry logic", async () => {
+      const provider = new MockAuthProvider()
+      const error = { response: { status: 401 } } as AxiosError
+
+      // First call should return true (retry)
+      const shouldRetry1 = await provider.handleAuthError(error)
+      expect(shouldRetry1).toBe(true)
+      expect(provider.getRetryCount()).toBe(1)
+
+      // Second call should return false (don't retry)
+      const shouldRetry2 = await provider.handleAuthError(error)
+      expect(shouldRetry2).toBe(false)
+      expect(provider.getRetryCount()).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
This pull request introduces changes to enhance the build process and improve the flexibility of the OpenAPI MCP Server by adding a CLI entry point and making the main function reusable for programmatic use. The most important changes include updates to the build script, the addition of a CLI entry point, and modifications to the `main` function in `src/index.ts`.

### Build process enhancements:
* [`build.js`](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L1-R5): Added a second build step to generate the CLI entry point (`src/cli.ts`) with appropriate settings for Node.js, including a shebang banner and external dependencies. Also added a log message to indicate when the build is complete. [[1]](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L1-R5) [[2]](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L14-R47)

### CLI support:
* [`src/cli.ts`](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR1-R6): Introduced a new CLI entry point that calls the `main` function from `src/index.ts`. This allows the server to be run directly from the command line.

### Programmatic usage improvements:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L10-R10): Modified the `main` function to only execute when the file is run directly, enabling programmatic usage without automatically starting the server. Exported the `main` function for external use. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L10-R10) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L41-R44) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R53-R55)