### PR TITLE
fix(config.ts): refactor parseHeaders function to correctly handle headers with semicolon

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,8 +38,12 @@ export function parseHeaders(headerStr?: string): Record<string, string> {
   const headers: Record<string, string> = {}
   if (headerStr) {
     headerStr.split(",").forEach((header) => {
-      const [key, value] = header.split(":")
-      if (key && value) headers[key.trim()] = value.trim()
+      const colonIndex = header.indexOf(":")
+      if (colonIndex > 0) {
+        const key = header.substring(0, colonIndex).trim()
+        const value = header.substring(colonIndex + 1).trim()
+        if (key && value) headers[key] = value
+      }
     })
   }
   return headers

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,6 +39,25 @@ describe("parseHeaders", () => {
       key2: "value2",
     })
   })
+
+  it("should handle header values containing colons", () => {
+    const headerStr = "Authorization:Bearer V:fffff,X-API-Key:key123"
+    const result = parseHeaders(headerStr)
+    expect(result).toEqual({
+      Authorization: "Bearer V:fffff",
+      "X-API-Key": "key123",
+    })
+  })
+
+  it("should handle multiple colons in header values", () => {
+    const headerStr =
+      "Content-Type:application/json,Authorization:Bearer token:with:multiple:colons"
+    const result = parseHeaders(headerStr)
+    expect(result).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token:with:multiple:colons",
+    })
+  })
 })
 
 describe("loadConfig", () => {


### PR DESCRIPTION
This pull request improves the `parseHeaders` function in `src/config.ts` to handle header values containing colons more robustly. Corresponding tests have been added to ensure the function behaves correctly in these scenarios.

### Improvements to `parseHeaders` function:
* Modified the logic in `parseHeaders` to use `indexOf` and `substring` for splitting headers, ensuring proper handling of header values containing colons. (`src/config.ts`, [src/config.tsL41-R46](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L41-R46))

### Additional test cases:
* Added a test to verify that `parseHeaders` correctly parses headers with colons in their values (e.g., `Authorization:Bearer V:fffff`). (`test/config.test.ts`, [test/config.test.tsR42-R60](diffhunk://#diff-68554a83416cb0dc26af312268fd38ba6024f0f1b222d37b984fd2d2032a26d5R42-R60))
* Added a test to validate handling of multiple colons within a single header value (e.g., `Authorization:Bearer token:with:multiple:colons`). (`test/config.test.ts`, [test/config.test.tsR42-R60](diffhunk://#diff-68554a83416cb0dc26af312268fd38ba6024f0f1b222d37b984fd2d2032a26d5R42-R60))