### PR TITLE
fix(api-client.ts): update paramRegex to include unique markers for path params

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -145,7 +145,7 @@ export class ApiClient {
             const escapedKey = escapeRegExp(key)
             // Try standard OpenAPI, Express-style parameters, and unique markers
             const paramRegex = new RegExp(
-              `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?:\\/|$)`,
+              `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?=__|/|$)`,
               "g",
             )
 
@@ -170,7 +170,7 @@ export class ApiClient {
           const escapedKey = escapeRegExp(key)
           // First try standard OpenAPI, Express-style parameters, and unique markers
           const paramRegex = new RegExp(
-            `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?:\\/|$)`,
+            `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?=__|/|$)`,
             "g",
           )
 

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -143,8 +143,11 @@ export class ApiClient {
           if (paramLocation === "path") {
             // Escape key before using it in regex patterns
             const escapedKey = escapeRegExp(key)
-            // Try standard OpenAPI and Express-style parameters first
-            const paramRegex = new RegExp(`\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)`, "g")
+            // Try standard OpenAPI, Express-style parameters, and unique markers
+            const paramRegex = new RegExp(
+              `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?:\\/|$)`,
+              "g",
+            )
 
             // If specific parameter style was found, use it
             if (paramRegex.test(resolvedPath)) {
@@ -165,8 +168,11 @@ export class ApiClient {
           const value = paramsCopy[key]
           // Escape key before using it in regex patterns
           const escapedKey = escapeRegExp(key)
-          // First try standard OpenAPI and Express-style parameters
-          const paramRegex = new RegExp(`\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)`, "g")
+          // First try standard OpenAPI, Express-style parameters, and unique markers
+          const paramRegex = new RegExp(
+            `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?:\\/|$)`,
+            "g",
+          )
 
           // If found, replace using regex
           if (paramRegex.test(resolvedPath)) {

--- a/src/utils/tool-id.ts
+++ b/src/utils/tool-id.ts
@@ -45,7 +45,7 @@ function sanitizeForToolId(input: string): string {
   return input
     .replace(/[^A-Za-z0-9_-]/g, "") // Remove any character not in the allowed set
     .replace(/_{3,}/g, "__") // Collapse 3+ consecutive underscores to double underscore (preserve path separators)
-    .replace(/-{4,}/g, "---") // Collapse 4+ consecutive hyphens to triple hyphen (preserve path param markers)
+    .replace(/(?<!-)-{4,}(?!-)/g, "---") // Collapse 4+ consecutive hyphens to triple hyphen, excluding valid triple hyphen markers
     .replace(/^[_-]+|[_-]+$/g, "") // Remove leading/trailing underscores and hyphens
 }
 

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -389,7 +389,7 @@ describe("Issue #33 Regression Test", () => {
  * handle these markers correctly.
  */
 
-// Tests for PR #38 review comment edge cases
+// Tests for Issue #33 and PR #38 review comment edge cases
 describe("PR #38 Review Comment Fixes", () => {
   describe("Parameter Matching Precision in API Client", () => {
     it("should not partially match parameter names that are substrings of path segments", async () => {

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -34,16 +34,19 @@ describe("ApiClient Dynamic Meta-Tools", () => {
             get: {
               summary: "Get users",
               description: "Retrieve all users",
+              responses: {},
             },
             post: {
               summary: "Create user",
               description: "Create a new user",
+              responses: {},
             },
           },
           "/users/{id}": {
             get: {
               summary: "Get user by ID",
               description: "Retrieve a specific user",
+              responses: {},
             },
           },
         },
@@ -136,12 +139,13 @@ describe("ApiClient Dynamic Meta-Tools", () => {
                   schema: { type: "integer" },
                 },
               ],
+              responses: {},
             },
           },
         },
       }
 
-      apiClient.setOpenApiSpec(openApiSpec)
+      apiClient.setOpenApiSpec(openApiSpec as any)
 
       const result = await apiClient.executeApiCall("GET-API-ENDPOINT-SCHEMA", {
         endpoint: "/users",
@@ -168,7 +172,7 @@ describe("ApiClient Dynamic Meta-Tools", () => {
         },
       }
 
-      apiClient.setOpenApiSpec(openApiSpec)
+      apiClient.setOpenApiSpec(openApiSpec as any)
       mockAxios.request.mockResolvedValue({ data: [{ id: 1, name: "John" }] })
 
       const result = await apiClient.executeApiCall("INVOKE-API-ENDPOINT", {
@@ -384,3 +388,216 @@ describe("Issue #33 Regression Test", () => {
  * location information, then updates the parameter replacement logic to
  * handle these markers correctly.
  */
+
+// Tests for PR #38 review comment edge cases
+describe("PR #38 Review Comment Fixes", () => {
+  describe("Parameter Matching Precision in API Client", () => {
+    it("should not partially match parameter names that are substrings of path segments", async () => {
+      const mockSpecLoader = new OpenAPISpecLoader()
+      const mockApiClient = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+      )
+
+      // Test case where parameter names could cause substring collisions
+      const testSpec = {
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/api/users/{userid}/info/{user}": {
+            get: {
+              operationId: "getUserInfo",
+              parameters: [
+                {
+                  name: "userid",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" as const },
+                },
+                {
+                  name: "user",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" as const },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      }
+
+      mockApiClient.setOpenApiSpec(testSpec as any)
+      const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+      mockApiClient.setTools(tools)
+
+      let capturedConfig: any = null
+      const mockAxios = vi.fn().mockImplementation((config) => {
+        capturedConfig = config
+        return Promise.resolve({ data: { success: true } })
+      })
+      ;(mockApiClient as any).axiosInstance = mockAxios
+
+      // This should NOT cause substring replacement issues
+      const toolId = "GET::api__users__---userid__info__---user"
+      await mockApiClient.executeApiCall(toolId, { userid: "456", user: "123" })
+
+      expect(capturedConfig.url).toBe("/api/users/456/info/123")
+      // Verify no partial matches occurred
+      expect(capturedConfig.url).not.toContain("456id") // Would indicate partial match of "user" in "userid"
+      expect(capturedConfig.url).not.toContain("123id")
+    })
+
+    it("should handle parameters with similar names without cross-contamination", async () => {
+      const mockSpecLoader = new OpenAPISpecLoader()
+      const mockApiClient = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+      )
+
+      const testSpec = {
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/api/{id}/data/{idNum}": {
+            get: {
+              operationId: "getIdData",
+              parameters: [
+                {
+                  name: "id",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" as const },
+                },
+                {
+                  name: "idNum",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" as const },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      }
+
+      mockApiClient.setOpenApiSpec(testSpec as any)
+      const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+      mockApiClient.setTools(tools)
+
+      let capturedConfig: any = null
+      const mockAxios = vi.fn().mockImplementation((config) => {
+        capturedConfig = config
+        return Promise.resolve({ data: { success: true } })
+      })
+      ;(mockApiClient as any).axiosInstance = mockAxios
+
+      const toolId = "GET::api__---id__data__---idNum"
+      await mockApiClient.executeApiCall(toolId, { id: "ABC", idNum: "789" })
+
+      expect(capturedConfig.url).toBe("/api/ABC/data/789")
+      // Ensure no cross-contamination between similar parameter names
+      expect(capturedConfig.url).not.toContain("ABCNum")
+      expect(capturedConfig.url).not.toContain("789Num")
+    })
+
+    it("should properly handle parameter replacement with double underscore boundaries", async () => {
+      const mockSpecLoader = new OpenAPISpecLoader()
+      const mockApiClient = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+      )
+
+      const testSpec = {
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/api/v1/{param}/nested/{param2}": {
+            get: {
+              operationId: "getNestedParam",
+              parameters: [
+                {
+                  name: "param",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" as const },
+                },
+                {
+                  name: "param2",
+                  in: "path",
+                  required: true,
+                  schema: { type: "string" as const },
+                },
+              ],
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      }
+
+      mockApiClient.setOpenApiSpec(testSpec as any)
+      const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+      mockApiClient.setTools(tools)
+
+      let capturedConfig: any = null
+      const mockAxios = vi.fn().mockImplementation((config) => {
+        capturedConfig = config
+        return Promise.resolve({ data: { success: true } })
+      })
+      ;(mockApiClient as any).axiosInstance = mockAxios
+
+      const toolId = "GET::api__v1__---param__nested__---param2"
+      await mockApiClient.executeApiCall(toolId, { param: "VALUE1", param2: "VALUE2" })
+
+      expect(capturedConfig.url).toBe("/api/v1/VALUE1/nested/VALUE2")
+      // Verify boundaries are respected and no partial replacement occurs
+      expect(capturedConfig.url).not.toContain("VALUE12") // param2 should not be affected by param replacement
+    })
+  })
+
+  describe("Sanitization Edge Cases", () => {
+    it("should handle paths with consecutive hyphens correctly in API calls", async () => {
+      const mockSpecLoader = new OpenAPISpecLoader()
+      const mockApiClient = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+      )
+
+      // Create a spec with a path that has consecutive hyphens that should be preserved
+      const testSpec = {
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/api/resource---name/items": {
+            get: {
+              operationId: "getResourceItems",
+              responses: { "200": { description: "Success" } },
+            },
+          },
+        },
+      }
+
+      mockApiClient.setOpenApiSpec(testSpec as any)
+      const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+      mockApiClient.setTools(tools)
+
+      let capturedConfig: any = null
+      const mockAxios = vi.fn().mockImplementation((config) => {
+        capturedConfig = config
+        return Promise.resolve({ data: { success: true } })
+      })
+      ;(mockApiClient as any).axiosInstance = mockAxios
+
+      // The tool ID should preserve the triple hyphens properly
+      const toolId = "GET::api__resource---name__items"
+      await mockApiClient.executeApiCall(toolId, {})
+
+      expect(capturedConfig.url).toBe("/api/resource---name/items")
+    })
+  })
+})

--- a/test/openapi-loader.test.ts
+++ b/test/openapi-loader.test.ts
@@ -385,7 +385,7 @@ paths:
 
     it("should handle various number-letter combinations when disableAbbreviation is true", () => {
       const loader = new OpenAPISpecLoader({ disableAbbreviation: true })
-      
+
       expect(loader.abbreviateOperationId("api2DataProcessor")).toBe("api2-data-processor")
       expect(loader.abbreviateOperationId("blockchain2Handler")).toBe("blockchain2-handler")
       expect(loader.abbreviateOperationId("v1ApiService")).toBe("v1-api-service")
@@ -400,7 +400,7 @@ paths:
       expect(tools.size).toBe(3)
       expect(tools.has("GET::users")).toBe(true)
       expect(tools.has("POST::users")).toBe(true)
-      expect(tools.has("GET::users__id")).toBe(true)
+      expect(tools.has("GET::users__---id")).toBe(true)
     })
 
     it("should set correct tool properties", () => {
@@ -424,7 +424,7 @@ paths:
 
     it("should handle required parameters", () => {
       const tools = openAPILoader.parseOpenAPISpec(mockOpenAPISpec)
-      const getUserByIdTool = tools.get("GET::users__id") as Tool
+      const getUserByIdTool = tools.get("GET::users__---id") as Tool
 
       expect(getUserByIdTool).toBeDefined()
       expect(getUserByIdTool.inputSchema).toEqual({
@@ -512,7 +512,7 @@ paths:
       expect(getUsersTool).toBeDefined()
       expect(getUsersTool.name).toBe("get-users")
 
-      const deleteUserTool = tools.get("DELETE::users__id") as Tool
+      const deleteUserTool = tools.get("DELETE::users__---id") as Tool
       expect(deleteUserTool).toBeDefined()
       expect(deleteUserTool.name).toBe("delete-users-id")
 
@@ -542,7 +542,7 @@ paths:
       const tools = openAPILoader.parseOpenAPISpec(specWithComplexPaths)
 
       const updateSettingsTool = tools.get(
-        "PUT::api__v2__user-management__profiles__userId__settings",
+        "PUT::api__v2__user-management__profiles__---userId__settings",
       ) as Tool
       expect(updateSettingsTool).toBeDefined()
       expect(updateSettingsTool.name).toBe("put-api-v-2-user-management-profiles-user-id-settings")

--- a/test/tool-id-utils.test.ts
+++ b/test/tool-id-utils.test.ts
@@ -160,7 +160,7 @@ describe("Tool ID Utilities", () => {
 
     it("should remove path parameter braces", () => {
       const result = generateToolId("GET", "/users/{id}/profile")
-      expect(result).toBe("GET::users__id__profile")
+      expect(result).toBe("GET::users__---id__profile")
     })
 
     it("should handle paths with underscores", () => {
@@ -170,7 +170,7 @@ describe("Tool ID Utilities", () => {
 
     it("should handle mixed separators and path params", () => {
       const result = generateToolId("DELETE", "/api_v2/user_management/{groupId}/members")
-      expect(result).toBe("DELETE::api_v2__user_management__groupId__members")
+      expect(result).toBe("DELETE::api_v2__user_management__---groupId__members")
     })
 
     it("should handle paths with hyphens (no escaping needed)", () => {
@@ -201,7 +201,7 @@ describe("Tool ID Utilities", () => {
 
       it("should remove at symbols and other email-like characters", () => {
         const result = generateToolId("PUT", "/users/{email@domain.com}/profile")
-        expect(result).toBe("PUT::users__emaildomaincom__profile")
+        expect(result).toBe("PUT::users__---emaildomaincom__profile")
       })
 
       it("should handle query parameter-like syntax", () => {
@@ -236,7 +236,7 @@ describe("Tool ID Utilities", () => {
           "POST",
           "/api/v2.0/users/{user@domain.com}/posts?filter=active&sort=date",
         )
-        expect(result).toBe("POST::api__v20__users__userdomaincom__postsfilteractivesortdate")
+        expect(result).toBe("POST::api__v20__users__---userdomaincom__postsfilteractivesortdate")
       })
 
       it("should preserve underscores in the sanitized output", () => {
@@ -286,8 +286,8 @@ describe("Tool ID Utilities", () => {
         // Method should match exactly
         expect(parsed.method).toBe(testCase.method.toUpperCase())
 
-        // Path should match the structure (path params will have braces removed)
-        const expectedPath = testCase.path.replace(/\{([^}]+)\}/g, "$1")
+        // Path should match the structure (path params will have ---param markers replaced back)
+        const expectedPath = testCase.path.replace(/\{([^}]+)\}/g, "---$1")
         expect(parsed.path).toBe(expectedPath)
       }
     })
@@ -601,7 +601,7 @@ describe("Tool ID Utilities", () => {
         {
           description: "Unicode in path parameters",
           path: "/api/users/{José}/profile",
-          expected: "GET::api__users__Jos__profile",
+          expected: "GET::api__users__---Jos__profile",
         },
         {
           description: "Unicode mixed with special characters",
@@ -688,7 +688,7 @@ describe("Tool ID Utilities", () => {
         {
           description: "Trailing slashes with path parameters",
           path: "/users/{id}/profile/",
-          expected: "GET::users__id__profile",
+          expected: "GET::users__---id__profile",
         },
       ]
 
@@ -753,7 +753,7 @@ describe("Tool ID Utilities", () => {
         {
           description: "Consecutive slashes with path parameters",
           path: "/users//{id}//profile",
-          expected: "GET::users__id__profile",
+          expected: "GET::users__---id__profile",
         },
         {
           description: "Consecutive slashes with hyphens",
@@ -816,7 +816,7 @@ describe("Tool ID Utilities", () => {
         {
           description: "Slashes with path parameters and special chars",
           path: "/users//{email@domain.com}//profile/",
-          expected: "GET::users__emaildomaincom__profile",
+          expected: "GET::users__---emaildomaincom__profile",
         },
       ]
 

--- a/test/tool-id-utils.test.ts
+++ b/test/tool-id-utils.test.ts
@@ -286,7 +286,7 @@ describe("Tool ID Utilities", () => {
         // Method should match exactly
         expect(parsed.method).toBe(testCase.method.toUpperCase())
 
-        // Path should match the structure (path params will have ---param markers replaced back)
+        // Path should match the structure with ---param markers for parameters
         const expectedPath = testCase.path.replace(/\{([^}]+)\}/g, "---$1")
         expect(parsed.path).toBe(expectedPath)
       }

--- a/test/tool-id-utils.test.ts
+++ b/test/tool-id-utils.test.ts
@@ -828,7 +828,7 @@ describe("Tool ID Utilities", () => {
   })
 })
 
-// New test section for PR #38 review comment issues
+// New test section addressing issue #33, incorporating review comments from PR #38
 describe("PR #38 Review Comment Edge Cases", () => {
   describe("Sanitization Issues with Consecutive Hyphens", () => {
     it("should preserve legitimate triple hyphens in path segments", () => {


### PR DESCRIPTION
fixes https://github.com/ivo-toby/mcp-openapi-server/issues/33