### PR TITLE
fix(package.json): correct bin field format for scoped package 

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "type": "git",
     "url": "https://github.com/ivo-toby/mcp-openapi-server"
   },
-  "bin": "./bin/mcp-server.js",
+  "bin": {
+    "openapi-mcp-server": "./bin/mcp-server.js"
+  },
   "files": [
-    "dist"
+    "dist",
+    "bin"
   ],
   "scripts": {
     "build": "node build.js && chmod +x bin/mcp-server.js",

--- a/test/package-structure.test.ts
+++ b/test/package-structure.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync, existsSync, statSync } from "fs"
+import { join } from "path"
+
+describe("Package Structure (Issue #49)", () => {
+  const packageJsonPath = join(process.cwd(), "package.json")
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"))
+
+  describe("bin field configuration", () => {
+    it("should have bin field as an object, not a string", () => {
+      expect(packageJson.bin).toBeDefined()
+      expect(typeof packageJson.bin).toBe("object")
+      expect(Array.isArray(packageJson.bin)).toBe(false)
+    })
+
+    it("should define openapi-mcp-server command", () => {
+      expect(packageJson.bin).toHaveProperty("openapi-mcp-server")
+      expect(packageJson.bin["openapi-mcp-server"]).toBe(
+        "./bin/mcp-server.js",
+      )
+    })
+
+    it("should point to an existing executable file", () => {
+      const binPath = join(
+        process.cwd(),
+        packageJson.bin["openapi-mcp-server"],
+      )
+      expect(existsSync(binPath)).toBe(true)
+
+      const stats = statSync(binPath)
+      expect(stats.isFile()).toBe(true)
+    })
+  })
+
+  describe("files field configuration", () => {
+    it("should include dist directory", () => {
+      expect(packageJson.files).toBeDefined()
+      expect(Array.isArray(packageJson.files)).toBe(true)
+      expect(packageJson.files).toContain("dist")
+    })
+
+    it("should include bin directory", () => {
+      expect(packageJson.files).toContain("bin")
+    })
+
+    it("should have both required directories for npm pack", () => {
+      const requiredDirs = ["dist", "bin"]
+      const missingDirs = requiredDirs.filter(
+        (dir) => !packageJson.files.includes(dir),
+      )
+
+      expect(missingDirs).toEqual([])
+    })
+  })
+
+  describe("package publishability", () => {
+    it("should have a valid package name for scoped packages", () => {
+      expect(packageJson.name).toMatch(/^@[\w-]+\/[\w-]+$/)
+    })
+
+    it("should have all required fields for npm publishing", () => {
+      expect(packageJson.name).toBeDefined()
+      expect(packageJson.version).toBeDefined()
+      expect(packageJson.description).toBeDefined()
+      expect(packageJson.license).toBeDefined()
+    })
+  })
+
+  describe("bin directory contents", () => {
+    it("should have mcp-server.js in bin directory", () => {
+      const binDir = join(process.cwd(), "bin")
+      const binFile = join(binDir, "mcp-server.js")
+
+      expect(existsSync(binDir)).toBe(true)
+      expect(existsSync(binFile)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
fixes https://github.com/ivo-toby/mcp-openapi-server/issues/49

Changes:
- Convert bin field from string to object mapping command name to script
- Add bin directory to files array to ensure executable is included in npm pack
- Add comprehensive test suite to verify package structure and publishability

This fixes the "openapi-mcp-server: not found" error when running npx -y @ivotoby/openapi-mcp-server. For scoped packages, npm requires bin to be an object that explicitly maps the command name to the script file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)