### PR TITLE
Improve colon handling: add validation and edge case tests

### DIFF
--- a/test/google-rpc-colon.test.ts
+++ b/test/google-rpc-colon.test.ts
@@ -145,17 +145,17 @@ describe("Issue: Tool ID sanitization drops RPC colon in paths", () => {
     // This is the exact scenario from the bug report
     const path = "/api/widgets/{widgetId}:activate"
     const method = "POST"
-    
+
     // Generate tool ID
     const toolId = generateToolId(method, path)
-    
+
     // Parse it back
     const parsed = parseToolId(toolId)
-    
+
     // The colon should be preserved
     expect(parsed.path).toContain(":activate")
     expect(parsed.path).toBe("/api/widgets/---widgetId:activate")
-    
+
     // Now simulate parameter replacement (what the API client does)
     const widgetId = "12345"
     const escapeRegExp = (str: string): string => {
@@ -166,17 +166,98 @@ describe("Issue: Tool ID sanitization drops RPC colon in paths", () => {
       `\\{${escapedKey}\\}|:${escapedKey}(?:\\/|$)|---${escapedKey}(?=__|/|:|$)`,
       "g",
     )
-    
+
     const finalPath = parsed.path.replace(
       paramRegex,
       (match) => encodeURIComponent(widgetId) + (match.endsWith("/") ? "/" : ""),
     )
-    
+
     // The final path should be correct
     expect(finalPath).toBe("/api/widgets/12345:activate")
-    
+
     // Should NOT be the broken version from the bug report
     expect(finalPath).not.toBe("/api/widgets/---widgetIdactivate")
     expect(finalPath).not.toContain("---")
+  })
+})
+
+describe("Edge cases for colon handling in tool IDs", () => {
+  it("should reject paths with double colons (::) as they conflict with tool ID separator", () => {
+    const path = "/api/test::action"
+    const method = "GET"
+
+    expect(() => generateToolId(method, path)).toThrow(
+      /contains double colons \(::\) which conflicts with the internal tool ID separator/,
+    )
+  })
+
+  it("should reject paths with :: in the middle of the path", () => {
+    const path = "/api/v1/resources::custom/{id}"
+    const method = "POST"
+
+    expect(() => generateToolId(method, path)).toThrow(
+      /contains double colons \(::\) which conflicts with the internal tool ID separator/,
+    )
+  })
+
+  it("should handle paths starting with colon (edge case)", () => {
+    const path = "/api/:action"
+    const method = "GET"
+
+    const toolId = generateToolId(method, path)
+    const parsed = parseToolId(toolId)
+
+    // Single colon should be preserved
+    expect(parsed.path).toBe("/api/:action")
+  })
+
+  it("should handle paths ending with colon (edge case)", () => {
+    const path = "/api/widgets:"
+    const method = "GET"
+
+    const toolId = generateToolId(method, path)
+    const parsed = parseToolId(toolId)
+
+    // Trailing colons are preserved
+    expect(parsed.path).toBe("/api/widgets:")
+  })
+
+  it("should handle paths with colons in the middle without RPC-style suffix", () => {
+    const path = "/api/v1:beta/resources"
+    const method = "GET"
+
+    const toolId = generateToolId(method, path)
+    const parsed = parseToolId(toolId)
+
+    // Colon in middle of path segment should be preserved
+    expect(parsed.path).toBe("/api/v1:beta/resources")
+  })
+
+  it("should handle multiple single colons in different parts of the path", () => {
+    const path = "/api/v1:beta/resources/{id}:activate"
+    const method = "POST"
+
+    const toolId = generateToolId(method, path)
+    const parsed = parseToolId(toolId)
+
+    // Both colons should be preserved
+    expect(parsed.path).toBe("/api/v1:beta/resources/---id:activate")
+  })
+
+  it("should provide clear error message for double colon paths", () => {
+    const path = "/api/namespace::method"
+    const method = "POST"
+
+    try {
+      generateToolId(method, path)
+      // Should not reach here
+      expect(true).toBe(false)
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error)
+      if (error instanceof Error) {
+        expect(error.message).toContain('"/api/namespace::method"')
+        expect(error.message).toContain("Single colons for Google RPC-style paths")
+      }
+    }
   })
 })


### PR DESCRIPTION
Based on PR review, this commit adds several improvements to the colon handling in Google RPC-style paths:

1. **Add validation for double colons (::)**
   - Paths containing :: now throw a clear error explaining the conflict
   - Prevents silent failures when :: appears in API paths
   - Helps developers understand the limitation upfront

2. **Fix regex character class ambiguity**
   - Changed /[^A-Za-z0-9_.:.-]/g to /[^A-Za-z0-9_.\-:]/g
   - Escapes hyphen to avoid potential range interpretation
   - Improves code clarity and maintainability

3. **Add comprehensive edge case tests**
   - Test rejection of paths with double colons
   - Test paths with colons at start, end, and middle
   - Test multiple single colons in same path
   - Test error messages for clarity
   - 7 new test cases (286 total tests, all passing)

4. **Document the limitation**
   - Added JSDoc notes about :: not being supported
   - Clarified that single colons are fully supported
   - Updated function examples with context

These improvements address potential edge cases while maintaining full backward compatibility for Google RPC-style paths like /widgets/{id}:activate.