### PR TITLE
Consider summary for operation if description is empty

### DIFF
--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -459,10 +459,11 @@ export class OpenAPISpecLoader {
 
         const nameSource = op.operationId || op.summary || `${method.toUpperCase()} ${path}`
         const name = this.abbreviateOperationId(nameSource)
+        const description = [op.summary, op.description].filter(x => x).join("\n");
 
         const tool: ExtendedTool = {
           name,
-          description: op.summary || op.description ? `${op.summary}\n${op.description}` : `Make a ${method.toUpperCase()} request to ${path}`,
+          description: description || `Make a ${method.toUpperCase()} request to ${path}`,
           inputSchema: {
             type: "object",
             properties: {},


### PR DESCRIPTION
Some openapi definitions are unfortunately bit brief and only specify the `summary` field and not `description`. But there should be no harm to use `summary` if no `description` is found.

Example file: https://intervals.icu/api/v1/docs