### PR TITLE
Enhance tool description with operation summary

### DIFF
--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -467,7 +467,7 @@ export class OpenAPISpecLoader {
 
         const tool: ExtendedTool = {
           name,
-          description: op.description || `Make a ${method.toUpperCase()} request to ${path}`,
+          description: op.description || op.summary || `Make a ${method.toUpperCase()} request to ${path}`,
           inputSchema: {
             type: "object",
             properties: {},


### PR DESCRIPTION
When I connected to my Swagger 2.0 API doc, I found that the interface description was actually in the summary field, so I hope to enhance logical judgment to obtain the correct description