### PR TITLE
fix: set Content-Type header for non-GET requests (#81)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for OIDC
+  id-token: write # Required for OIDC
   issues: write
   pull-requests: write
 
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -39,5 +39,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -16,6 +16,19 @@
     "dist",
     "bin"
   ],
+  "release": {
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      [
+        "@semantic-release/github",
+        {
+          "labels": false
+        }
+      ]
+    ]
+  },
   "scripts": {
     "build": "node build.js && chmod +x bin/mcp-server.js",
     "clean": "rm -rf dist",

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -600,7 +600,7 @@ export class ApiClient {
     const config: any = {
       method: method.toLowerCase(),
       url: path,
-      headers: authHeaders,
+      headers: { ...authHeaders },
     }
 
     // Handle parameters based on HTTP method

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -99,6 +99,59 @@ export class ApiClient {
     return this.toolsMap.get(toolId)
   }
 
+  private resolveRequestBodyObject(
+    requestBody: OpenAPIV3.RequestBodyObject | OpenAPIV3.ReferenceObject | undefined,
+  ): OpenAPIV3.RequestBodyObject | undefined {
+    if (!requestBody || !("$ref" in requestBody)) {
+      return requestBody
+    }
+
+    const refPrefix = "#/components/requestBodies/"
+    if (!requestBody.$ref.startsWith(refPrefix)) {
+      return undefined
+    }
+
+    const requestBodyName = requestBody.$ref.slice(refPrefix.length)
+    const resolvedRequestBody = this.openApiSpec?.components?.requestBodies?.[requestBodyName]
+
+    if (!resolvedRequestBody || "$ref" in resolvedRequestBody) {
+      return undefined
+    }
+
+    return resolvedRequestBody
+  }
+
+  private getRequestContentType(method: string, path: string): string | undefined {
+    const pathItem = this.openApiSpec?.paths[path]
+    const normalizedMethod = method.toLowerCase()
+
+    if (!isValidHttpMethod(normalizedMethod)) {
+      return undefined
+    }
+
+    const operation = (pathItem as any)?.[normalizedMethod] as
+      | OpenAPIV3.OperationObject
+      | OpenAPIV3.ReferenceObject
+      | undefined
+
+    if (!operation || "$ref" in operation) {
+      return undefined
+    }
+
+    const requestBody = this.resolveRequestBodyObject(operation.requestBody)
+    const content = requestBody?.content
+
+    if (!content) {
+      return undefined
+    }
+
+    if (content["application/json"]) {
+      return "application/json"
+    }
+
+    return Object.keys(content)[0]
+  }
+
   /**
    * Execute an API call based on the tool ID and parameters
    *
@@ -610,7 +663,8 @@ export class ApiClient {
     } else {
       // For POST-like methods, parameters go in the request body
       config.data = params
-      config.headers["Content-Type"] = "application/json"
+      config.headers["Content-Type"] =
+        this.getRequestContentType(method, path) || "application/json"
     }
 
     try {

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -13,6 +13,7 @@ import { OpenAPIV3 } from "openapi-types"
  */
 const SYSTEM_CONTROLLED_HEADERS = new Set([
   "host", // Controlled by HTTP client based on URL
+  "content-type", // Set automatically based on OpenAPI spec or defaults
   "content-length", // Calculated by HTTP client from body
   "transfer-encoding", // Managed by HTTP client for chunked encoding
   "connection", // HTTP connection management
@@ -281,6 +282,10 @@ export class ApiClient {
       } else {
         // For POST-like methods, remaining parameters go in the request body
         config.data = Object.keys(paramsCopy).length > 0 ? paramsCopy : {}
+
+        // Set Content-Type from OpenAPI spec metadata, defaulting to application/json
+        const contentType = (toolDef?.inputSchema as any)?.["x-content-type"] || "application/json"
+        config.headers["Content-Type"] = contentType
       }
 
       // Execute the request
@@ -605,6 +610,7 @@ export class ApiClient {
     } else {
       // For POST-like methods, parameters go in the request body
       config.data = params
+      config.headers["Content-Type"] = "application/json"
     }
 
     try {

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -608,13 +608,21 @@ export class OpenAPISpecLoader {
 
           // Handle different content types
           let mediaTypeObj: OpenAPIV3.MediaTypeObject | undefined
+          let selectedContentType: string | undefined
 
           if (requestBodyObj.content["application/json"]) {
             mediaTypeObj = requestBodyObj.content["application/json"]
+            selectedContentType = "application/json"
           } else if (Object.keys(requestBodyObj.content).length > 0) {
             // Take the first available content type
             const firstContentType = Object.keys(requestBodyObj.content)[0]
             mediaTypeObj = requestBodyObj.content[firstContentType]
+            selectedContentType = firstContentType
+          }
+
+          // Store the content type in the tool's input schema for use by ApiClient
+          if (selectedContentType) {
+            ;(tool.inputSchema as any)["x-content-type"] = selectedContentType
           }
 
           if (mediaTypeObj?.schema) {

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -620,11 +620,6 @@ export class OpenAPISpecLoader {
             selectedContentType = firstContentType
           }
 
-          // Store the content type in the tool's input schema for use by ApiClient
-          if (selectedContentType) {
-            ;(tool.inputSchema as any)["x-content-type"] = selectedContentType
-          }
-
           if (mediaTypeObj?.schema) {
             // Handle schema inlining with proper types
             const inlinedSchema = this.inlineSchema(
@@ -676,6 +671,11 @@ export class OpenAPISpecLoader {
               tool.inputSchema.properties!["body"] = inlinedSchema
               requiredParams.push("body")
             }
+          }
+
+          // Store the content type in the final input schema for use by ApiClient
+          if (selectedContentType) {
+            ;(tool.inputSchema as any)["x-content-type"] = selectedContentType
           }
         }
 

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1108,11 +1108,7 @@ describe("Issue #50: Header Parameter Support", () => {
     const mockAuthProvider = new StaticAuthProvider({
       Authorization: "Bearer real-auth-token",
     })
-    const mockApiClient = new ApiClient(
-      "https://api.example.com",
-      mockAuthProvider,
-      mockSpecLoader,
-    )
+    const mockApiClient = new ApiClient("https://api.example.com", mockAuthProvider, mockSpecLoader)
 
     const testSpec = {
       openapi: "3.0.0",
@@ -1588,6 +1584,56 @@ describe("Issue #81: Content-Type header support", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           "Content-Type": "application/json",
+        }),
+      }),
+    )
+  })
+
+  it("should use spec-defined Content-Type in makeDirectHttpRequest for POST via INVOKE-API-ENDPOINT", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const openApiSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          post: {
+            summary: "Create user",
+            requestBody: {
+              content: {
+                "application/xml": {
+                  schema: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(openApiSpec as any)
+    const mockAxios = {
+      request: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    }
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    await mockApiClient.executeApiCall("INVOKE-API-ENDPOINT", {
+      endpoint: "/users",
+      method: "POST",
+      params: { body: "<user><name>John</name></user>" },
+    })
+
+    expect(mockAxios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/xml",
         }),
       }),
     )

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -785,8 +785,9 @@ describe("Issue #50: Header Parameter Support", () => {
       value: "test-value",
     })
 
-    // Verify header parameter is in headers
+    // Verify header parameter is in headers along with Content-Type
     expect(capturedConfig.headers).toEqual({
+      "Content-Type": "application/json",
       "x-request-id": "req-12345",
     })
 
@@ -1201,6 +1202,50 @@ describe("Issue #50: Header Parameter Support", () => {
     expect(capturedConfig.headers["x-custom-header"]).toBe("normal-value")
   })
 
+  it("should block content-type as system-controlled header", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/data": {
+          get: {
+            parameters: [
+              {
+                name: "Content-Type",
+                in: "header",
+                required: false,
+                schema: { type: "string" },
+              },
+            ],
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    const mockAxios = vi.fn().mockImplementation(() => {
+      return Promise.resolve({ data: { success: true } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "GET::api__data"
+
+    await expect(
+      mockApiClient.executeApiCall(toolId, { "Content-Type": "text/plain" }),
+    ).rejects.toThrow('Cannot set system-controlled header "Content-Type"')
+  })
+
   it("should prevent setting system-controlled headers", async () => {
     const mockSpecLoader = new OpenAPISpecLoader()
     const mockApiClient = new ApiClient(
@@ -1252,5 +1297,401 @@ describe("Issue #50: Header Parameter Support", () => {
     await expect(
       mockApiClient.executeApiCall("GET::api__data", { "Content-Length": "999" }),
     ).rejects.toThrow('Cannot set system-controlled header "Content-Length"')
+  })
+})
+
+// Tests for Issue #81: Content-Type header not set for POST/PUT/PATCH requests
+describe("Issue #81: Content-Type header support", () => {
+  it("should set Content-Type application/json for POST requests with body", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/users": {
+          post: {
+            operationId: "createUser",
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object" as const,
+                    properties: {
+                      name: { type: "string" as const },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: { id: 1 } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "POST::api__users"
+    await mockApiClient.executeApiCall(toolId, { name: "John" })
+
+    expect(capturedConfig.headers["Content-Type"]).toBe("application/json")
+  })
+
+  it("should set Content-Type application/json for PUT requests with body", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/users/{id}": {
+          put: {
+            operationId: "updateUser",
+            parameters: [
+              {
+                name: "id",
+                in: "path",
+                required: true,
+                schema: { type: "string" as const },
+              },
+            ],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object" as const,
+                    properties: {
+                      name: { type: "string" as const },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "Updated" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: { id: 1 } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "PUT::api__users__---id"
+    await mockApiClient.executeApiCall(toolId, { id: "1", name: "Jane" })
+
+    expect(capturedConfig.headers["Content-Type"]).toBe("application/json")
+  })
+
+  it("should set Content-Type from OpenAPI spec when not application/json", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/data": {
+          post: {
+            operationId: "postData",
+            requestBody: {
+              content: {
+                "application/xml": {
+                  schema: {
+                    type: "object" as const,
+                    properties: {
+                      data: { type: "string" as const },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: { ok: true } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "POST::api__data"
+    await mockApiClient.executeApiCall(toolId, { data: "<xml/>" })
+
+    expect(capturedConfig.headers["Content-Type"]).toBe("application/xml")
+  })
+
+  it("should not set Content-Type for GET requests", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/users": {
+          get: {
+            operationId: "getUsers",
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: [] })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "GET::api__users"
+    await mockApiClient.executeApiCall(toolId, {})
+
+    expect(capturedConfig.headers["Content-Type"]).toBeUndefined()
+  })
+
+  it("should set Content-Type for POST with empty body", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/trigger": {
+          post: {
+            operationId: "trigger",
+            responses: { "200": { description: "Success" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: { ok: true } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "POST::api__trigger"
+    await mockApiClient.executeApiCall(toolId, {})
+
+    expect(capturedConfig.headers["Content-Type"]).toBe("application/json")
+  })
+
+  it("should set Content-Type for POST without tool definition (fallback)", async () => {
+    const mockApiClient = new ApiClient("https://api.example.com", new StaticAuthProvider())
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: { ok: true } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "POST::api__data"
+    await mockApiClient.executeApiCall(toolId, { key: "value" })
+
+    expect(capturedConfig.headers["Content-Type"]).toBe("application/json")
+  })
+
+  it("should set Content-Type in makeDirectHttpRequest for POST via INVOKE-API-ENDPOINT", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const openApiSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          post: {
+            summary: "Create user",
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(openApiSpec as any)
+    const mockAxios = {
+      request: vi.fn().mockResolvedValue({ data: { id: 1 } }),
+    }
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    await mockApiClient.executeApiCall("INVOKE-API-ENDPOINT", {
+      endpoint: "/users",
+      method: "POST",
+      params: { name: "John" },
+    })
+
+    expect(mockAxios.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    )
+  })
+
+  it("should not set Content-Type in makeDirectHttpRequest for GET via INVOKE-API-ENDPOINT", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(),
+      mockSpecLoader,
+    )
+
+    const openApiSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/users": {
+          get: {
+            summary: "Get users",
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(openApiSpec as any)
+    const mockAxios = {
+      request: vi.fn().mockResolvedValue({ data: [] }),
+    }
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    await mockApiClient.executeApiCall("INVOKE-API-ENDPOINT", {
+      endpoint: "/users",
+      method: "GET",
+      params: {},
+    })
+
+    const callHeaders = mockAxios.request.mock.calls[0][0].headers
+    expect(callHeaders["Content-Type"]).toBeUndefined()
+  })
+
+  it("should merge Content-Type with auth headers and custom headers for POST", async () => {
+    const mockSpecLoader = new OpenAPISpecLoader()
+    const authHeaders = { Authorization: "Bearer token" }
+    const mockApiClient = new ApiClient(
+      "https://api.example.com",
+      new StaticAuthProvider(authHeaders),
+      mockSpecLoader,
+    )
+
+    const testSpec = {
+      openapi: "3.0.0",
+      info: { title: "Test API", version: "1.0.0" },
+      paths: {
+        "/api/resources": {
+          post: {
+            operationId: "createResource",
+            parameters: [
+              {
+                name: "x-request-id",
+                in: "header",
+                required: true,
+                schema: { type: "string" as const },
+              },
+            ],
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object" as const,
+                    properties: {
+                      name: { type: "string" as const },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      },
+    }
+
+    mockApiClient.setOpenApiSpec(testSpec as any)
+    const tools = mockSpecLoader.parseOpenAPISpec(testSpec as any)
+    mockApiClient.setTools(tools)
+
+    let capturedConfig: any = null
+    const mockAxios = vi.fn().mockImplementation((config) => {
+      capturedConfig = config
+      return Promise.resolve({ data: { id: 1 } })
+    })
+    ;(mockApiClient as any).axiosInstance = mockAxios
+
+    const toolId = "POST::api__resources"
+    await mockApiClient.executeApiCall(toolId, {
+      "x-request-id": "req-123",
+      name: "test",
+    })
+
+    expect(capturedConfig.headers).toEqual({
+      Authorization: "Bearer token",
+      "x-request-id": "req-123",
+      "Content-Type": "application/json",
+    })
   })
 })


### PR DESCRIPTION
POST/PUT/PATCH requests were missing the Content-Type header, causing 415 errors with APIs that require it. The content type from the OpenAPI spec's requestBody.content is now stored as x-content-type metadata on tool schemas and used when making requests, defaulting to application/json.

Fixes #81 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound HTTP header behavior for all non-GET requests (including meta-tool direct invokes), which can impact API compatibility if content types differ from expectations. Release pipeline configuration also changes (semantic-release config + removed `NPM_TOKEN` from workflow), which could affect publishing.
> 
> **Overview**
> Fixes missing `Content-Type` on POST/PUT/PATCH-style requests by propagating the OpenAPI `requestBody.content` media type into generated tool schemas (`x-content-type`) and using it in `ApiClient` when building request headers (defaulting to `application/json`).
> 
> Extends the same behavior to `INVOKE-API-ENDPOINT` direct HTTP calls by resolving requestBody refs from the loaded OpenAPI spec, and treats `content-type` as a system-controlled header that users cannot override.
> 
> Updates release automation by adding `semantic-release` plugin config in `package.json` and adjusting the GitHub Actions release workflow (including removing `NPM_TOKEN` from the job env).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 097c6197522c94bb6cb53628cbf22726fb0d0ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->