### PR TITLE
feat: add mTLS client authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ npx @ivotoby/openapi-mcp-server \
 
 This is orthogonal to HTTP-level auth, so mTLS can be combined with static headers or an `AuthProvider`.
 
+TLS-related options only apply when `--api-base-url` uses `https://`.
+
 For private CAs or encrypted keys:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The server supports two transport methods:
 No need to clone this repository. Simply configure Claude Desktop to use this MCP server:
 
 1. Locate or create your Claude Desktop configuration file:
-
    - On macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 2. Add the following configuration:
@@ -120,6 +119,11 @@ The server can be configured through environment variables or command line argum
 - `OPENAPI_SPEC_FROM_STDIN` - Set to "true" to read OpenAPI spec from standard input
 - `OPENAPI_SPEC_INLINE` - Provide OpenAPI spec content directly as a string
 - `API_HEADERS` - Comma-separated key:value pairs for API headers
+- `CLIENT_CERT_PATH` - Path to client certificate PEM file for mutual TLS
+- `CLIENT_KEY_PATH` - Path to client private key PEM file for mutual TLS
+- `CA_CERT_PATH` - Path to custom CA certificate PEM file for private/internal CAs
+- `CLIENT_KEY_PASSPHRASE` - Passphrase for an encrypted client private key
+- `REJECT_UNAUTHORIZED` - Whether to reject untrusted server certificates (default: `true`)
 - `SERVER_NAME` - Name for the MCP server (default: "mcp-openapi-server")
 - `SERVER_VERSION` - Version of the server (default: "1.0.0")
 - `TRANSPORT_TYPE` - Transport type to use: "stdio" or "http" (default: "stdio")
@@ -140,6 +144,8 @@ npx @ivotoby/openapi-mcp-server \
   --api-base-url https://api.example.com \
   --openapi-spec https://api.example.com/openapi.json \
   --headers "Authorization:Bearer token123,X-API-Key:your-api-key" \
+  --client-cert ./certs/client.pem \
+  --client-key ./certs/client-key.pem \
   --name "my-mcp-server" \
   --server-version "1.0.0" \
   --transport http \
@@ -148,6 +154,40 @@ npx @ivotoby/openapi-mcp-server \
   --path /mcp \
   --disable-abbreviation true
 ```
+
+## Mutual TLS (mTLS)
+
+If your upstream API requires client certificate authentication, you can attach TLS credentials directly to outbound requests.
+
+```bash
+npx @ivotoby/openapi-mcp-server \
+  --api-base-url https://secure-api.example.com \
+  --openapi-spec https://secure-api.example.com/openapi.json \
+  --client-cert ./certs/client.pem \
+  --client-key ./certs/client-key.pem \
+  --headers "Authorization:Bearer token123"
+```
+
+This is orthogonal to HTTP-level auth, so mTLS can be combined with static headers or an `AuthProvider`.
+
+For private CAs or encrypted keys:
+
+```bash
+npx @ivotoby/openapi-mcp-server \
+  --api-base-url https://internal-api.example.com \
+  --openapi-spec ./openapi.yaml \
+  --client-cert ./certs/client.pem \
+  --client-key ./certs/client-key.pem \
+  --client-key-passphrase "$CLIENT_KEY_PASSPHRASE" \
+  --ca-cert ./certs/internal-ca.pem \
+  --reject-unauthorized false
+```
+
+- `--client-cert` / `CLIENT_CERT_PATH`: client certificate PEM file
+- `--client-key` / `CLIENT_KEY_PATH`: client private key PEM file
+- `--client-key-passphrase` / `CLIENT_KEY_PASSPHRASE`: passphrase for encrypted private keys
+- `--ca-cert` / `CA_CERT_PATH`: custom CA bundle for private/internal certificate authorities
+- `--reject-unauthorized` / `REJECT_UNAUTHORIZED`: set to `false` only when you intentionally want to allow self-signed or otherwise untrusted server certificates
 
 ## OpenAPI Specification Loading
 
@@ -286,11 +326,11 @@ In addition to exposing OpenAPI endpoints as **tools**, this server can expose *
 
 ### What Are Prompts and Resources?
 
-| Feature | Purpose | Use Case |
-|---------|---------|----------|
-| **Tools** | API endpoints for the AI to execute | Making API calls |
-| **Prompts** | Templated messages with argument substitution | Reusable workflow templates |
-| **Resources** | Read-only content for context | API documentation, schemas |
+| Feature       | Purpose                                       | Use Case                    |
+| ------------- | --------------------------------------------- | --------------------------- |
+| **Tools**     | API endpoints for the AI to execute           | Making API calls            |
+| **Prompts**   | Templated messages with argument substitution | Reusable workflow templates |
+| **Resources** | Read-only content for context                 | API documentation, schemas  |
 
 ### Loading Prompts
 
@@ -434,11 +474,13 @@ curl http://localhost:3000/health
 ```
 
 **Health Response Fields:**
+
 - `status`: Always returns "healthy" when server is running
 - `activeSessions`: Number of active MCP sessions
 - `uptime`: Server uptime in seconds
 
 **Key Features:**
+
 - No authentication required
 - Works with any HTTP method (GET, POST, etc.)
 - Ideal for load balancers, Kubernetes probes, and monitoring systems
@@ -470,7 +512,6 @@ HEALTHCHECK --interval=30s --timeout=3s \
 To see debug logs:
 
 1. When using stdio transport with Claude Desktop:
-
    - Logs appear in the Claude Desktop logs
 
 2. When using HTTP transport:
@@ -630,15 +671,16 @@ if (resourcesManager) {
 
 ```typescript
 interface PromptDefinition {
-  name: string            // Unique identifier
-  title?: string          // Human-readable display title
-  description?: string    // Description of the prompt
-  arguments?: {           // Template arguments
+  name: string // Unique identifier
+  title?: string // Human-readable display title
+  description?: string // Description of the prompt
+  arguments?: {
+    // Template arguments
     name: string
     description?: string
     required?: boolean
   }[]
-  template: string        // Template with {{argName}} placeholders
+  template: string // Template with {{argName}} placeholders
 }
 ```
 
@@ -646,14 +688,14 @@ interface PromptDefinition {
 
 ```typescript
 interface ResourceDefinition {
-  uri: string             // Unique URI identifier
-  name: string            // Resource name
-  title?: string          // Human-readable display title
-  description?: string    // Description of the resource
-  mimeType?: string       // Content MIME type
-  text?: string           // Static text content
-  blob?: string           // Static binary content (base64)
-  contentProvider?: () => Promise<string | { blob: string }>  // Dynamic content
+  uri: string // Unique URI identifier
+  name: string // Resource name
+  title?: string // Human-readable display title
+  description?: string // Description of the resource
+  mimeType?: string // Content MIME type
+  text?: string // Static text content
+  blob?: string // Static binary content (base64)
+  contentProvider?: () => Promise<string | { blob: string }> // Dynamic content
 }
 ```
 

--- a/openspec/changes/add-mtls-client-auth/proposal.md
+++ b/openspec/changes/add-mtls-client-auth/proposal.md
@@ -1,0 +1,17 @@
+# Change: Add mTLS client certificate support
+
+## Why
+
+Some APIs require mutual TLS at the transport layer, so header-based authentication alone is not enough. The server needs a way to attach a client certificate and private key to outgoing HTTPS requests, and optionally relax server certificate verification for development environments.
+
+## What Changes
+
+- Add config options for `clientCertPath`, `clientKeyPath`, `caCertPath`, `clientKeyPassphrase`, and `rejectUnauthorized` via CLI flags and environment variables
+- Load certificate material from PEM files and configure the API client with an HTTPS agent for outbound requests
+- Keep mTLS orthogonal to existing header-based and dynamic authentication flows
+- Document the new CLI and environment options with usage examples, including private CA and encrypted key usage
+
+## Impact
+
+- Affected specs: `mtls-client-auth`
+- Affected code: `src/config.ts`, `src/server.ts`, `src/api-client.ts`, relevant tests, `README.md`

--- a/openspec/changes/add-mtls-client-auth/specs/mtls-client-auth/spec.md
+++ b/openspec/changes/add-mtls-client-auth/specs/mtls-client-auth/spec.md
@@ -23,10 +23,15 @@ The server SHALL configure outbound API requests with client certificate materia
 - **WHEN** the server is configured with both a client certificate path and client key path
 - **THEN** outbound API requests use an HTTPS agent initialized with the loaded PEM certificate and key
 
-#### Scenario: Server certificate validation override is disabled
+#### Scenario: TLS verification is disabled
 
 - **WHEN** the user sets `rejectUnauthorized` to `false`
 - **THEN** the HTTPS agent allows self-signed or otherwise untrusted server certificates
+
+#### Scenario: TLS options require HTTPS upstream URLs
+
+- **WHEN** the user provides TLS-related settings for an `apiBaseUrl` that does not use `https://`
+- **THEN** the server fails fast with a clear configuration error
 
 #### Scenario: Private CA bundle is configured
 

--- a/openspec/changes/add-mtls-client-auth/specs/mtls-client-auth/spec.md
+++ b/openspec/changes/add-mtls-client-auth/specs/mtls-client-auth/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Client certificate configuration
+
+The server SHALL accept mutual TLS client certificate and TLS trust settings through CLI flags and environment variables.
+
+#### Scenario: CLI provides mTLS settings
+
+- **WHEN** the user starts the server with `--client-cert`, `--client-key`, `--ca-cert`, `--client-key-passphrase`, and `--reject-unauthorized`
+- **THEN** the loaded configuration includes those values
+
+#### Scenario: Environment provides mTLS settings
+
+- **WHEN** the user sets `CLIENT_CERT_PATH`, `CLIENT_KEY_PATH`, `CA_CERT_PATH`, `CLIENT_KEY_PASSPHRASE`, or `REJECT_UNAUTHORIZED`
+- **THEN** the loaded configuration uses those values when CLI flags are not provided
+
+### Requirement: Outbound HTTPS requests support mTLS
+
+The server SHALL configure outbound API requests with client certificate material when mutual TLS settings are provided.
+
+#### Scenario: mTLS is enabled
+
+- **WHEN** the server is configured with both a client certificate path and client key path
+- **THEN** outbound API requests use an HTTPS agent initialized with the loaded PEM certificate and key
+
+#### Scenario: Server certificate validation override is disabled
+
+- **WHEN** the user sets `rejectUnauthorized` to `false`
+- **THEN** the HTTPS agent allows self-signed or otherwise untrusted server certificates
+
+#### Scenario: Private CA bundle is configured
+
+- **WHEN** the user provides a custom CA certificate path
+- **THEN** the HTTPS agent trusts server certificates signed by that CA bundle
+
+#### Scenario: Encrypted private key is configured
+
+- **WHEN** the user provides a client key passphrase
+- **THEN** the HTTPS agent uses that passphrase when loading the private key
+
+### Requirement: HTTP authentication remains compatible with mTLS
+
+The server SHALL continue to support header-based and dynamic authentication when mutual TLS is enabled.
+
+#### Scenario: mTLS and HTTP auth are both configured
+
+- **WHEN** the server has mTLS settings and either static headers or an `AuthProvider`
+- **THEN** the API client uses the HTTPS agent and the existing HTTP authentication behavior together

--- a/openspec/changes/add-mtls-client-auth/tasks.md
+++ b/openspec/changes/add-mtls-client-auth/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+
+- [x] 1.1 Add configuration coverage for client certificate paths, CA bundle path, key passphrase, and TLS verification settings
+- [x] 1.2 Add failing tests for passing HTTPS agent settings from server config into the API client
+- [x] 1.3 Implement HTTPS agent creation and wiring in the server and API client
+- [x] 1.4 Update README examples and option documentation for mTLS usage, custom CA bundles, and encrypted keys
+- [x] 1.5 Run targeted tests for config and server behavior

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosError } from "axios"
 import { Tool } from "@modelcontextprotocol/sdk/types.js"
+import type { Agent as HttpsAgent } from "node:https"
 import { AuthProvider, StaticAuthProvider, isAuthError } from "./auth-provider.js"
 import { parseToolId as parseToolIdUtil, generateToolId } from "./utils/tool-id.js"
 import { isValidHttpMethod, isGetLikeMethod, VALID_HTTP_METHODS } from "./utils/http-methods.js"
@@ -40,11 +41,13 @@ export class ApiClient {
    * @param baseUrl - Base URL for the API
    * @param authProviderOrHeaders - AuthProvider instance or static headers for backward compatibility
    * @param specLoader - Optional OpenAPI spec loader for dynamic meta-tools
+   * @param options - Optional HTTP client configuration
    */
   constructor(
     baseUrl: string,
     authProviderOrHeaders?: AuthProvider | Record<string, string>,
     specLoader?: OpenAPISpecLoader,
+    options?: ApiClientOptions,
   ) {
     this.axiosInstance = axios.create({
       baseURL: baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`,
@@ -52,6 +55,7 @@ export class ApiClient {
       maxContentLength: 50 * 1024 * 1024, // 50MB response body limit
       maxBodyLength: 50 * 1024 * 1024, // 50MB request body limit
       maxRedirects: 5, // Limit redirect chains to prevent abuse
+      httpsAgent: options?.httpsAgent,
     })
 
     // Handle backward compatibility
@@ -688,4 +692,8 @@ export class ApiClient {
       throw error
     }
   }
+}
+
+export interface ApiClientOptions {
+  httpsAgent?: HttpsAgent
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -157,7 +157,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       description: "Passphrase for encrypted client private key",
     })
     .option("reject-unauthorized", {
-      type: "boolean",
+      type: "string",
       description: "Whether to reject untrusted server certificates",
     })
     .option("name", {

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ export interface OpenAPIMCPServerConfig {
   clientKeyPath?: string
   caCertPath?: string
   clientKeyPassphrase?: string
-  rejectUnauthorized: boolean
+  rejectUnauthorized?: boolean
   transportType: "stdio" | "http"
   httpPort?: number
   httpHost?: string
@@ -67,6 +67,30 @@ export function parseHeaders(headerStr?: string): Record<string, string> {
     })
   }
   return headers
+}
+
+function parseOptionalBoolean(value: unknown, optionName: string): boolean | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined
+  }
+
+  if (typeof value === "boolean") {
+    return value
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${optionName} must be a boolean value`)
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true
+  }
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false
+  }
+
+  throw new Error(`${optionName} must be one of: true, false, 1, 0, yes, no, on, off`)
 }
 
 /**
@@ -273,9 +297,10 @@ export function loadConfig(): OpenAPIMCPServerConfig {
   }
 
   const headers = parseHeaders(argv.headers || process.env.API_HEADERS)
-  const rejectUnauthorizedInput =
-    argv["reject-unauthorized"] ??
-    (process.env.REJECT_UNAUTHORIZED ? process.env.REJECT_UNAUTHORIZED === "true" : undefined)
+  const rejectUnauthorizedInput = parseOptionalBoolean(
+    argv["reject-unauthorized"] ?? process.env.REJECT_UNAUTHORIZED,
+    "rejectUnauthorized",
+  )
 
   return {
     name: argv.name || process.env.SERVER_NAME || "mcp-openapi-server",

--- a/src/config.ts
+++ b/src/config.ts
@@ -299,7 +299,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
   const headers = parseHeaders(argv.headers || process.env.API_HEADERS)
   const rejectUnauthorizedInput = parseOptionalBoolean(
     argv["reject-unauthorized"] ?? process.env.REJECT_UNAUTHORIZED,
-    "rejectUnauthorized",
+    "--reject-unauthorized/REJECT_UNAUTHORIZED",
   )
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,11 @@ export interface OpenAPIMCPServerConfig {
   headers?: Record<string, string>
   /** AuthProvider for dynamic authentication (takes precedence over headers) */
   authProvider?: AuthProvider
+  clientCertPath?: string
+  clientKeyPath?: string
+  caCertPath?: string
+  clientKeyPassphrase?: string
+  rejectUnauthorized: boolean
   transportType: "stdio" | "http"
   httpPort?: number
   httpHost?: string
@@ -110,6 +115,26 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       alias: "H",
       type: "string",
       description: "API headers in format 'key1:value1,key2:value2'",
+    })
+    .option("client-cert", {
+      type: "string",
+      description: "Path to client certificate PEM file for mutual TLS",
+    })
+    .option("client-key", {
+      type: "string",
+      description: "Path to client private key PEM file for mutual TLS",
+    })
+    .option("ca-cert", {
+      type: "string",
+      description: "Path to custom CA certificate PEM file",
+    })
+    .option("client-key-passphrase", {
+      type: "string",
+      description: "Passphrase for encrypted client private key",
+    })
+    .option("reject-unauthorized", {
+      type: "boolean",
+      description: "Whether to reject untrusted server certificates",
     })
     .option("name", {
       alias: "n",
@@ -239,9 +264,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     if (normalized === "all" || normalized === "dynamic" || normalized === "explicit") {
       toolsMode = normalized
     } else {
-      throw new Error(
-        "Invalid tools mode. Expected one of: all, dynamic, explicit",
-      )
+      throw new Error("Invalid tools mode. Expected one of: all, dynamic, explicit")
     }
   }
 
@@ -250,6 +273,9 @@ export function loadConfig(): OpenAPIMCPServerConfig {
   }
 
   const headers = parseHeaders(argv.headers || process.env.API_HEADERS)
+  const rejectUnauthorizedInput =
+    argv["reject-unauthorized"] ??
+    (process.env.REJECT_UNAUTHORIZED ? process.env.REJECT_UNAUTHORIZED === "true" : undefined)
 
   return {
     name: argv.name || process.env.SERVER_NAME || "mcp-openapi-server",
@@ -259,6 +285,12 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     specInputMethod,
     inlineSpecContent,
     headers,
+    clientCertPath: (argv["client-cert"] as string | undefined) || process.env.CLIENT_CERT_PATH,
+    clientKeyPath: (argv["client-key"] as string | undefined) || process.env.CLIENT_KEY_PATH,
+    caCertPath: (argv["ca-cert"] as string | undefined) || process.env.CA_CERT_PATH,
+    clientKeyPassphrase:
+      (argv["client-key-passphrase"] as string | undefined) || process.env.CLIENT_KEY_PASSPHRASE,
+    rejectUnauthorized: rejectUnauthorizedInput ?? true,
     transportType,
     httpPort,
     httpHost,
@@ -272,6 +304,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     promptsPath: (argv.prompts as string | undefined) || process.env.PROMPTS_PATH,
     promptsInline: (argv["prompts-inline"] as string | undefined) || process.env.PROMPTS_INLINE,
     resourcesPath: (argv.resources as string | undefined) || process.env.RESOURCES_PATH,
-    resourcesInline: (argv["resources-inline"] as string | undefined) || process.env.RESOURCES_INLINE,
+    resourcesInline:
+      (argv["resources-inline"] as string | undefined) || process.env.RESOURCES_INLINE,
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,6 +92,10 @@ export class OpenAPIServer {
       return undefined
     }
 
+    if (!this.config.apiBaseUrl.startsWith("https://")) {
+      throw new Error("TLS options require apiBaseUrl to use https://")
+    }
+
     const httpsAgentOptions: ConstructorParameters<typeof HttpsAgent>[0] = {
       rejectUnauthorized,
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,7 +92,14 @@ export class OpenAPIServer {
       return undefined
     }
 
-    if (!this.config.apiBaseUrl.startsWith("https://")) {
+    let apiUrl: URL
+    try {
+      apiUrl = new URL(this.config.apiBaseUrl.trim())
+    } catch {
+      throw new Error("TLS options require apiBaseUrl to be a valid https:// URL")
+    }
+
+    if (apiUrl.protocol !== "https:") {
       throw new Error("TLS options require apiBaseUrl to use https://")
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,29 +73,44 @@ export class OpenAPIServer {
   }
 
   private createApiClientOptions(): ApiClientOptions | undefined {
+    const hasClientCert = !!this.config.clientCertPath
+    const hasClientKey = !!this.config.clientKeyPath
+
+    if (hasClientCert !== hasClientKey) {
+      throw new Error("clientCertPath and clientKeyPath must be provided together")
+    }
+
+    const rejectUnauthorized = this.config.rejectUnauthorized ?? true
     const shouldConfigureHttpsAgent =
-      !!this.config.clientCertPath ||
-      !!this.config.clientKeyPath ||
+      hasClientCert ||
+      hasClientKey ||
       !!this.config.caCertPath ||
       !!this.config.clientKeyPassphrase ||
-      this.config.rejectUnauthorized === false
+      rejectUnauthorized === false
 
     if (!shouldConfigureHttpsAgent) {
       return undefined
     }
 
+    const httpsAgentOptions: ConstructorParameters<typeof HttpsAgent>[0] = {
+      rejectUnauthorized,
+    }
+
+    if (this.config.clientCertPath) {
+      httpsAgentOptions.cert = readFileSync(this.config.clientCertPath, "utf8")
+    }
+    if (this.config.clientKeyPath) {
+      httpsAgentOptions.key = readFileSync(this.config.clientKeyPath, "utf8")
+    }
+    if (this.config.caCertPath) {
+      httpsAgentOptions.ca = readFileSync(this.config.caCertPath, "utf8")
+    }
+    if (this.config.clientKeyPassphrase) {
+      httpsAgentOptions.passphrase = this.config.clientKeyPassphrase
+    }
+
     return {
-      httpsAgent: new HttpsAgent({
-        cert: this.config.clientCertPath
-          ? readFileSync(this.config.clientCertPath, "utf8")
-          : undefined,
-        key: this.config.clientKeyPath
-          ? readFileSync(this.config.clientKeyPath, "utf8")
-          : undefined,
-        ca: this.config.caCertPath ? readFileSync(this.config.caCertPath, "utf8") : undefined,
-        passphrase: this.config.clientKeyPassphrase,
-        rejectUnauthorized: this.config.rejectUnauthorized,
-      }),
+      httpsAgent: new HttpsAgent(httpsAgentOptions),
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
+import { readFileSync } from "node:fs"
+import { Agent as HttpsAgent } from "node:https"
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
@@ -11,7 +13,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { OpenAPIMCPServerConfig } from "./config"
 import { ToolsManager } from "./tools-manager"
-import { ApiClient } from "./api-client"
+import { ApiClient, type ApiClientOptions } from "./api-client"
 import { StaticAuthProvider } from "./auth-provider.js"
 import { PromptsManager } from "./prompts-manager"
 import { ResourcesManager } from "./resources-manager"
@@ -52,21 +54,49 @@ export class OpenAPIServer {
       capabilities.resources = {}
     }
 
-    this.server = new Server(
-      { name: config.name, version: config.version },
-      { capabilities },
-    )
+    this.server = new Server({ name: config.name, version: config.version }, { capabilities })
     this.toolsManager = new ToolsManager(config)
 
     // Use AuthProvider if provided, otherwise fallback to static headers
     const authProviderOrHeaders = config.authProvider || new StaticAuthProvider(config.headers)
-    this.apiClient = new ApiClient(
-      config.apiBaseUrl,
-      authProviderOrHeaders,
-      this.toolsManager.getSpecLoader(),
-    )
+    const apiClientOptions = this.createApiClientOptions()
+    this.apiClient = apiClientOptions
+      ? new ApiClient(
+          config.apiBaseUrl,
+          authProviderOrHeaders,
+          this.toolsManager.getSpecLoader(),
+          apiClientOptions,
+        )
+      : new ApiClient(config.apiBaseUrl, authProviderOrHeaders, this.toolsManager.getSpecLoader())
 
     this.initializeHandlers()
+  }
+
+  private createApiClientOptions(): ApiClientOptions | undefined {
+    const shouldConfigureHttpsAgent =
+      !!this.config.clientCertPath ||
+      !!this.config.clientKeyPath ||
+      !!this.config.caCertPath ||
+      !!this.config.clientKeyPassphrase ||
+      this.config.rejectUnauthorized === false
+
+    if (!shouldConfigureHttpsAgent) {
+      return undefined
+    }
+
+    return {
+      httpsAgent: new HttpsAgent({
+        cert: this.config.clientCertPath
+          ? readFileSync(this.config.clientCertPath, "utf8")
+          : undefined,
+        key: this.config.clientKeyPath
+          ? readFileSync(this.config.clientKeyPath, "utf8")
+          : undefined,
+        ca: this.config.caCertPath ? readFileSync(this.config.caCertPath, "utf8") : undefined,
+        passphrase: this.config.clientKeyPassphrase,
+        rejectUnauthorized: this.config.rejectUnauthorized,
+      }),
+    }
   }
 
   /**
@@ -141,10 +171,7 @@ export class OpenAPIServer {
       }))
 
       this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
-        return this.promptsManager!.getPrompt(
-          request.params.name,
-          request.params.arguments,
-        )
+        return this.promptsManager!.getPrompt(request.params.name, request.params.arguments)
       })
     }
 
@@ -196,4 +223,3 @@ export class OpenAPIServer {
     return this.resourcesManager
   }
 }
-

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,13 +80,13 @@ export class OpenAPIServer {
       throw new Error("clientCertPath and clientKeyPath must be provided together")
     }
 
+    if (this.config.clientKeyPassphrase && !hasClientKey) {
+      throw new Error("clientKeyPassphrase requires clientKeyPath and clientCertPath")
+    }
+
     const rejectUnauthorized = this.config.rejectUnauthorized ?? true
     const shouldConfigureHttpsAgent =
-      hasClientCert ||
-      hasClientKey ||
-      !!this.config.caCertPath ||
-      !!this.config.clientKeyPassphrase ||
-      rejectUnauthorized === false
+      hasClientCert || hasClientKey || !!this.config.caCertPath || rejectUnauthorized === false
 
     if (!shouldConfigureHttpsAgent) {
       return undefined

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -150,10 +150,19 @@ describe("loadConfig", () => {
       headers: {
         Authorization: "Bearer token",
       },
+      clientCertPath: undefined,
+      clientKeyPath: undefined,
+      caCertPath: undefined,
+      clientKeyPassphrase: undefined,
+      rejectUnauthorized: true,
       transportType: "stdio",
       httpPort: 3000,
       httpHost: "127.0.0.1",
       endpointPath: "/mcp",
+      promptsPath: undefined,
+      promptsInline: undefined,
+      resourcesPath: undefined,
+      resourcesInline: undefined,
       includeTools: undefined,
       includeTags: undefined,
       includeResources: undefined,
@@ -245,10 +254,19 @@ describe("loadConfig", () => {
       headers: {
         "X-API-Key": "12345",
       },
+      clientCertPath: undefined,
+      clientKeyPath: undefined,
+      caCertPath: undefined,
+      clientKeyPassphrase: undefined,
+      rejectUnauthorized: true,
       transportType: "stdio",
       httpPort: 3000,
       httpHost: "127.0.0.1",
       endpointPath: "/mcp",
+      promptsPath: undefined,
+      promptsInline: undefined,
+      resourcesPath: undefined,
+      resourcesInline: undefined,
       includeTools: undefined,
       includeTags: undefined,
       includeResources: undefined,
@@ -421,10 +439,19 @@ describe("loadConfig", () => {
       headers: {
         Authorization: "Bearer token",
       },
+      clientCertPath: undefined,
+      clientKeyPath: undefined,
+      caCertPath: undefined,
+      clientKeyPassphrase: undefined,
+      rejectUnauthorized: true,
       transportType: "stdio",
       httpPort: 3000,
       httpHost: "127.0.0.1",
       endpointPath: "/mcp",
+      promptsPath: undefined,
+      promptsInline: undefined,
+      resourcesPath: undefined,
+      resourcesInline: undefined,
       includeTools: undefined,
       includeTags: undefined,
       includeResources: undefined,
@@ -455,6 +482,68 @@ describe("loadConfig", () => {
     const config = loadConfig()
     expect(config.specInputMethod).toBe("file")
     expect(config.openApiSpec).toBe("./spec.json")
+  })
+
+  it("should load mTLS options from command line arguments", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+          "client-cert": "/tmp/client.pem",
+          "client-key": "/tmp/client-key.pem",
+          "ca-cert": "/tmp/ca.pem",
+          "client-key-passphrase": "secret-passphrase",
+          "reject-unauthorized": false,
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    const { loadConfig } = await import("../src/config")
+
+    const config = loadConfig()
+    expect(config.clientCertPath).toBe("/tmp/client.pem")
+    expect(config.clientKeyPath).toBe("/tmp/client-key.pem")
+    expect(config.caCertPath).toBe("/tmp/ca.pem")
+    expect(config.clientKeyPassphrase).toBe("secret-passphrase")
+    expect(config.rejectUnauthorized).toBe(false)
+  })
+
+  it("should load mTLS options from environment variables", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({}),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    process.env.API_BASE_URL = "https://env.example.com"
+    process.env.OPENAPI_SPEC_PATH = "./env-spec.json"
+    process.env.CLIENT_CERT_PATH = "/env/client.pem"
+    process.env.CLIENT_KEY_PATH = "/env/client-key.pem"
+    process.env.CA_CERT_PATH = "/env/ca.pem"
+    process.env.CLIENT_KEY_PASSPHRASE = "env-passphrase"
+    process.env.REJECT_UNAUTHORIZED = "false"
+
+    const { loadConfig } = await import("../src/config")
+
+    const config = loadConfig()
+    expect(config.clientCertPath).toBe("/env/client.pem")
+    expect(config.clientKeyPath).toBe("/env/client-key.pem")
+    expect(config.caCertPath).toBe("/env/ca.pem")
+    expect(config.clientKeyPassphrase).toBe("env-passphrase")
+    expect(config.rejectUnauthorized).toBe(false)
   })
 
   it("should load config with stdin spec", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -99,6 +99,11 @@ describe("loadConfig", () => {
     delete process.env.ENDPOINT_PATH
     delete process.env.TOOLS_MODE
     delete process.env.DISABLE_ABBREVIATION
+    delete process.env.CLIENT_CERT_PATH
+    delete process.env.CLIENT_KEY_PATH
+    delete process.env.CA_CERT_PATH
+    delete process.env.CLIENT_KEY_PASSPHRASE
+    delete process.env.REJECT_UNAUTHORIZED
 
     // Reset mocks before each test
     vi.clearAllMocks()
@@ -544,6 +549,51 @@ describe("loadConfig", () => {
     expect(config.caCertPath).toBe("/env/ca.pem")
     expect(config.clientKeyPassphrase).toBe("env-passphrase")
     expect(config.rejectUnauthorized).toBe(false)
+  })
+
+  it("should treat uppercase true env values as enabled TLS verification", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({}),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    process.env.API_BASE_URL = "https://env.example.com"
+    process.env.OPENAPI_SPEC_PATH = "./env-spec.json"
+    process.env.REJECT_UNAUTHORIZED = "TRUE"
+
+    const { loadConfig } = await import("../src/config")
+
+    const config = loadConfig()
+    expect(config.rejectUnauthorized).toBe(true)
+  })
+
+  it("should reject invalid rejectUnauthorized env values", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({}),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    process.env.API_BASE_URL = "https://env.example.com"
+    process.env.OPENAPI_SPEC_PATH = "./env-spec.json"
+    process.env.REJECT_UNAUTHORIZED = "definitely"
+
+    const { loadConfig } = await import("../src/config")
+
+    expect(() => loadConfig()).toThrow("rejectUnauthorized must be one of")
   })
 
   it("should load config with stdin spec", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -616,7 +616,7 @@ describe("loadConfig", () => {
 
     const { loadConfig } = await import("../src/config")
 
-    expect(() => loadConfig()).toThrow("rejectUnauthorized must be one of")
+    expect(() => loadConfig()).toThrow("--reject-unauthorized/REJECT_UNAUTHORIZED must be one of")
   })
 
   it("should load config with stdin spec", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -520,6 +520,29 @@ describe("loadConfig", () => {
     expect(config.rejectUnauthorized).toBe(false)
   })
 
+  it("should parse rejectUnauthorized from CLI string values", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+          "reject-unauthorized": "false",
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    const { loadConfig } = await import("../src/config")
+
+    const config = loadConfig()
+    expect(config.rejectUnauthorized).toBe(false)
+  })
+
   it("should load mTLS options from environment variables", async () => {
     vi.doMock("yargs", () => ({
       default: vi.fn().mockReturnValue({

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -586,6 +586,17 @@ describe("OpenAPIServer", () => {
       )
     })
 
+    it("should reject clientKeyPassphrase without mTLS key material", () => {
+      const invalidTlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        clientKeyPassphrase: "top-secret",
+      }
+
+      expect(() => new OpenAPIServer(invalidTlsConfig)).toThrow(
+        "clientKeyPassphrase requires clientKeyPath and clientCertPath",
+      )
+    })
+
     it("should reject TLS options for non-https apiBaseUrl", () => {
       const invalidTlsConfig: OpenAPIMCPServerConfig = {
         ...config,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -5,11 +5,15 @@ import type { AuthProvider } from "../src/auth-provider"
 vi.mock("@modelcontextprotocol/sdk/server/index.js")
 vi.mock("@modelcontextprotocol/sdk/server/transport.js")
 vi.mock("@modelcontextprotocol/sdk/types.js")
+vi.mock("node:fs")
+vi.mock("node:https")
 vi.mock("../src/tools-manager")
 vi.mock("../src/api-client")
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
+import * as fs from "node:fs"
+import * as https from "node:https"
 
 // Create a dummy interface that implements the Transport interface
 interface ServerTransport extends Transport {
@@ -84,6 +88,14 @@ describe("OpenAPIServer", () => {
           setTools: vi.fn(),
           setOpenApiSpec: vi.fn(),
         }) as any,
+    )
+
+    vi.mocked(fs.readFileSync).mockImplementation((filePath: fs.PathOrFileDescriptor) => {
+      return `mock:${String(filePath)}`
+    })
+
+    vi.mocked(https.Agent).mockImplementation(
+      (options?: https.AgentOptions) => ({ options }) as https.Agent,
     )
 
     server = new OpenAPIServer(config)
@@ -507,6 +519,58 @@ describe("OpenAPIServer", () => {
 
       // Verify ApiClient was constructed with the AuthProvider, not the headers
       expect(ApiClient).toHaveBeenCalledWith(config.apiBaseUrl, mockAuthProvider, expect.anything())
+    })
+
+    it("should create an HTTPS agent for mTLS settings", () => {
+      const mtlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        clientCertPath: "/certs/client.pem",
+        clientKeyPath: "/certs/client-key.pem",
+        caCertPath: "/certs/ca.pem",
+        clientKeyPassphrase: "top-secret",
+        rejectUnauthorized: false,
+      }
+
+      new OpenAPIServer(mtlsConfig)
+
+      expect(fs.readFileSync).toHaveBeenCalledWith("/certs/client.pem", "utf8")
+      expect(fs.readFileSync).toHaveBeenCalledWith("/certs/client-key.pem", "utf8")
+      expect(fs.readFileSync).toHaveBeenCalledWith("/certs/ca.pem", "utf8")
+      expect(https.Agent).toHaveBeenCalledWith({
+        cert: "mock:/certs/client.pem",
+        key: "mock:/certs/client-key.pem",
+        ca: "mock:/certs/ca.pem",
+        passphrase: "top-secret",
+        rejectUnauthorized: false,
+      })
+      expect(ApiClient).toHaveBeenCalledWith(
+        config.apiBaseUrl,
+        expect.objectContaining({
+          getAuthHeaders: expect.any(Function),
+          handleAuthError: expect.any(Function),
+        }),
+        expect.anything(),
+        { httpsAgent: expect.anything() },
+      )
+    })
+
+    it("should create an HTTPS agent when only TLS verification override is set", () => {
+      const tlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        rejectUnauthorized: false,
+      }
+
+      new OpenAPIServer(tlsConfig)
+
+      expect(https.Agent).toHaveBeenCalledWith({
+        rejectUnauthorized: false,
+      })
+      expect(ApiClient).toHaveBeenCalledWith(
+        config.apiBaseUrl,
+        expect.anything(),
+        expect.anything(),
+        { httpsAgent: expect.anything() },
+      )
     })
   })
 })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -524,6 +524,7 @@ describe("OpenAPIServer", () => {
     it("should create an HTTPS agent for mTLS settings", () => {
       const mtlsConfig: OpenAPIMCPServerConfig = {
         ...config,
+        apiBaseUrl: "https://localhost",
         clientCertPath: "/certs/client.pem",
         clientKeyPath: "/certs/client-key.pem",
         caCertPath: "/certs/ca.pem",
@@ -544,7 +545,7 @@ describe("OpenAPIServer", () => {
         rejectUnauthorized: false,
       })
       expect(ApiClient).toHaveBeenCalledWith(
-        config.apiBaseUrl,
+        mtlsConfig.apiBaseUrl,
         expect.objectContaining({
           getAuthHeaders: expect.any(Function),
           handleAuthError: expect.any(Function),
@@ -557,6 +558,7 @@ describe("OpenAPIServer", () => {
     it("should create an HTTPS agent when only TLS verification override is set", () => {
       const tlsConfig: OpenAPIMCPServerConfig = {
         ...config,
+        apiBaseUrl: "https://localhost",
         rejectUnauthorized: false,
       }
 
@@ -566,7 +568,7 @@ describe("OpenAPIServer", () => {
         rejectUnauthorized: false,
       })
       expect(ApiClient).toHaveBeenCalledWith(
-        config.apiBaseUrl,
+        tlsConfig.apiBaseUrl,
         expect.anything(),
         expect.anything(),
         { httpsAgent: expect.anything() },
@@ -581,6 +583,17 @@ describe("OpenAPIServer", () => {
 
       expect(() => new OpenAPIServer(invalidTlsConfig)).toThrow(
         "clientCertPath and clientKeyPath must be provided together",
+      )
+    })
+
+    it("should reject TLS options for non-https apiBaseUrl", () => {
+      const invalidTlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        rejectUnauthorized: false,
+      }
+
+      expect(() => new OpenAPIServer(invalidTlsConfig)).toThrow(
+        "TLS options require apiBaseUrl to use https://",
       )
     })
   })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -572,5 +572,16 @@ describe("OpenAPIServer", () => {
         { httpsAgent: expect.anything() },
       )
     })
+
+    it("should reject partial mTLS configuration", () => {
+      const invalidTlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        clientCertPath: "/certs/client.pem",
+      }
+
+      expect(() => new OpenAPIServer(invalidTlsConfig)).toThrow(
+        "clientCertPath and clientKeyPath must be provided together",
+      )
+    })
   })
 })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -596,5 +596,31 @@ describe("OpenAPIServer", () => {
         "TLS options require apiBaseUrl to use https://",
       )
     })
+
+    it("should allow uppercase HTTPS apiBaseUrl when TLS options are set", () => {
+      const tlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        apiBaseUrl: "  HTTPS://localhost  ",
+        rejectUnauthorized: false,
+      }
+
+      new OpenAPIServer(tlsConfig)
+
+      expect(https.Agent).toHaveBeenCalledWith({
+        rejectUnauthorized: false,
+      })
+    })
+
+    it("should reject invalid apiBaseUrl when TLS options are set", () => {
+      const invalidTlsConfig: OpenAPIMCPServerConfig = {
+        ...config,
+        apiBaseUrl: "not-a-url",
+        rejectUnauthorized: false,
+      }
+
+      expect(() => new OpenAPIServer(invalidTlsConfig)).toThrow(
+        "TLS options require apiBaseUrl to be a valid https:// URL",
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary
- add CLI and environment config for mTLS client certs, private keys, custom CA bundles, key passphrases, and TLS verification control
- wire those settings into an outbound `https.Agent` so API requests can use mTLS alongside existing header-based or dynamic auth
- add TDD coverage for config and server wiring, update README usage docs, and include the approved OpenSpec change

## Verification
- `npm test -- test/config.test.ts test/server.test.ts`
- `openspec validate add-mtls-client-auth --strict`

Fixes https://github.com/ivo-toby/mcp-openapi-server/issues/78


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound HTTP/TLS configuration and introduces options that can disable certificate verification, so misconfiguration could impact connectivity or security; changes are otherwise localized and well-tested.
> 
> **Overview**
> Adds **mutual TLS (mTLS) support** for upstream API calls by introducing new CLI/env config (`--client-cert`, `--client-key`, `--ca-cert`, `--client-key-passphrase`, `--reject-unauthorized`) and passing a configured `https.Agent` into the Axios client.
> 
> The server now **validates TLS config early** (requires cert+key together, forbids TLS options for non-`https://` `apiBaseUrl`) and includes expanded unit tests plus updated README docs and an OpenSpec change record for the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1efa712381762d7d21b6a273f78b0c6346044f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->