### PR TITLE
feat: add configurable logging verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The server can be configured through environment variables or command line argum
 - `ENDPOINT_PATH` - Endpoint path for HTTP transport (default: "/mcp")
 - `TOOLS_MODE` - Tools loading mode: "all" (load all endpoint-based tools), "dynamic" (load only meta-tools), or "explicit" (load only tools specified in includeTools) (default: "all")
 - `DISABLE_ABBREVIATION` - Disable name optimization (this could throw errors when name is > 64 chars)
+- `VERBOSE` - Enable operational logging (`true` by default; set to `false` to suppress non-essential logs)
 - `PROMPTS_PATH` - Path or URL to prompts JSON/YAML file
 - `PROMPTS_INLINE` - Provide prompts directly as JSON string
 - `RESOURCES_PATH` - Path or URL to resources JSON/YAML file
@@ -152,7 +153,8 @@ npx @ivotoby/openapi-mcp-server \
   --port 3000 \
   --host 127.0.0.1 \
   --path /mcp \
-  --disable-abbreviation true
+  --disable-abbreviation true \
+  --verbose false
 ```
 
 ## Mutual TLS (mTLS)
@@ -190,6 +192,8 @@ npx @ivotoby/openapi-mcp-server \
 - `--client-key-passphrase` / `CLIENT_KEY_PASSPHRASE`: passphrase for encrypted private keys
 - `--ca-cert` / `CA_CERT_PATH`: custom CA bundle for private/internal certificate authorities
 - `--reject-unauthorized` / `REJECT_UNAUTHORIZED`: set to `false` only when you intentionally want to allow self-signed or otherwise untrusted server certificates
+
+Set `--verbose false` or `VERBOSE=false` if you want the server to stay quiet in scripts or embedded environments.
 
 ## OpenAPI Specification Loading
 

--- a/openspec/changes/add-configurable-logging/proposal.md
+++ b/openspec/changes/add-configurable-logging/proposal.md
@@ -1,0 +1,17 @@
+# Change: Add configurable logging verbosity
+
+## Why
+
+The server currently writes operational and diagnostic logs unconditionally. That is noisy in embedded and automated environments, and there is no supported way to reduce output without patching the code.
+
+## What Changes
+
+- Add a `verbose` configuration option exposed through CLI flags and environment variables
+- Route existing internal warning and error logging through a shared logger that respects the configured verbosity
+- Preserve current behavior by default so existing users still see logs unless they explicitly disable them
+- Document the new logging controls and their defaults
+
+## Impact
+
+- Affected specs: `logging-verbosity`
+- Affected code: `src/config.ts`, `src/index.ts`, `src/server.ts`, `src/openapi-loader.ts`, `src/tools-manager.ts`, `src/transport/StreamableHttpServerTransport.ts`, related tests, `README.md`

--- a/openspec/changes/add-configurable-logging/specs/logging-verbosity/spec.md
+++ b/openspec/changes/add-configurable-logging/specs/logging-verbosity/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Configurable logging verbosity
+
+The server SHALL allow users to control operational logging verbosity through CLI flags and environment variables.
+
+#### Scenario: Verbose logging is enabled by default
+
+- **WHEN** the user starts the server without setting any logging verbosity option
+- **THEN** operational logs remain enabled for backward compatibility
+
+#### Scenario: CLI disables verbose logging
+
+- **WHEN** the user starts the server with a verbosity flag that disables logging
+- **THEN** the loaded configuration disables non-essential logs
+
+#### Scenario: Environment disables verbose logging
+
+- **WHEN** the user sets an environment variable that disables verbose logging
+- **THEN** the loaded configuration disables non-essential logs unless CLI flags override it
+
+### Requirement: Internal logs respect configured verbosity
+
+The server SHALL route internal warning and error logs through a shared logger that respects the configured verbosity.
+
+#### Scenario: Verbose logging is disabled
+
+- **WHEN** the logger receives warning or error messages while verbose logging is disabled
+- **THEN** those messages are not written to stderr
+
+#### Scenario: Verbose logging is enabled
+
+- **WHEN** the logger receives warning or error messages while verbose logging is enabled
+- **THEN** those messages are written to stderr

--- a/openspec/changes/add-configurable-logging/tasks.md
+++ b/openspec/changes/add-configurable-logging/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+
+- [x] 1.1 Add failing tests for verbose config parsing and logger behavior
+- [x] 1.2 Implement a shared logger and wire verbose config through the server components
+- [x] 1.3 Update docs for CLI and environment logging controls
+- [x] 1.4 Run targeted verification for config, logger, and affected server behavior

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,7 @@ export interface OpenAPIMCPServerConfig {
   resourcesPath?: string
   /** Inline resources JSON content */
   resourcesInline?: string
+  verbose?: boolean
 }
 
 /**
@@ -215,6 +216,10 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       type: "string",
       description: "Provide resources directly as JSON string",
     })
+    .option("verbose", {
+      type: "string",
+      description: "Enable verbose logging",
+    })
     .help()
     .parseSync()
 
@@ -301,6 +306,8 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     argv["reject-unauthorized"] ?? process.env.REJECT_UNAUTHORIZED,
     "--reject-unauthorized/REJECT_UNAUTHORIZED",
   )
+  const verbose =
+    parseOptionalBoolean(argv.verbose ?? process.env.VERBOSE, "--verbose/VERBOSE") ?? true
 
   return {
     name: argv.name || process.env.SERVER_NAME || "mcp-openapi-server",
@@ -331,5 +338,6 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     resourcesPath: (argv.resources as string | undefined) || process.env.RESOURCES_PATH,
     resourcesInline:
       (argv["resources-inline"] as string | undefined) || process.env.RESOURCES_INLINE,
+    verbose,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
       logger.error("OpenAPI MCP Server running on stdio")
     }
   } catch (error) {
-    logger.error("Failed to start server:", error)
+    logger.fatal("Failed to start server:", error)
     process.exit(1)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,20 +6,24 @@ import { OpenAPIServer } from "./server"
 import { loadConfig } from "./config"
 import { StreamableHttpServerTransport } from "./transport/StreamableHttpServerTransport"
 import { loadPrompts, loadResources } from "./content-loader"
+import { Logger } from "./utils/logger"
 
 /**
  * Main entry point for CLI usage
  */
 async function main(): Promise<void> {
+  const logger = new Logger(true)
+
   try {
     const config = loadConfig()
+    logger.setVerbose(config.verbose)
 
     // Load prompts from file/URL/inline if specified
     if (config.promptsPath || config.promptsInline) {
       const prompts = await loadPrompts(config.promptsPath, config.promptsInline)
       if (prompts) {
         config.prompts = prompts
-        console.error(`Loaded ${prompts.length} prompt(s)`)
+        logger.error(`Loaded ${prompts.length} prompt(s)`)
       }
     }
 
@@ -28,7 +32,7 @@ async function main(): Promise<void> {
       const resources = await loadResources(config.resourcesPath, config.resourcesInline)
       if (resources) {
         config.resources = resources
-        console.error(`Loaded ${resources.length} resource(s)`)
+        logger.error(`Loaded ${resources.length} resource(s)`)
       }
     }
 
@@ -41,18 +45,20 @@ async function main(): Promise<void> {
         config.httpPort!,
         config.httpHost,
         config.endpointPath,
+        undefined,
+        config.verbose,
       )
       await server.start(transport)
-      console.error(
+      logger.error(
         `OpenAPI MCP Server running on http://${config.httpHost}:${config.httpPort}${config.endpointPath}`,
       )
     } else {
       transport = new StdioServerTransport()
       await server.start(transport)
-      console.error("OpenAPI MCP Server running on stdio")
+      logger.error("OpenAPI MCP Server running on stdio")
     }
   } catch (error) {
-    console.error("Failed to start server:", error)
+    logger.error("Failed to start server:", error)
     process.exit(1)
   }
 }
@@ -69,6 +75,7 @@ export * from "./prompts-manager"
 export * from "./resources-manager"
 export * from "./prompt-types"
 export * from "./resource-types"
+export * from "./utils/logger"
 
 // Export the main function for programmatic usage
 export { main }

--- a/src/openapi-loader.ts
+++ b/src/openapi-loader.ts
@@ -5,6 +5,7 @@ import yaml, { CORE_SCHEMA } from "js-yaml"
 import crypto from "crypto"
 import { REVISED_COMMON_WORDS_TO_REMOVE, WORD_ABBREVIATIONS } from "./utils/abbreviations.js"
 import { generateToolId } from "./utils/tool-id.js"
+import { Logger } from "./utils/logger.js"
 
 /**
  * Extended Tool interface with metadata for filtering
@@ -35,9 +36,11 @@ export class OpenAPISpecLoader {
    * Disable name optimization
    */
   private disableAbbreviation: boolean
+  private logger: Logger
 
-  constructor(config?: { disableAbbreviation?: boolean }) {
+  constructor(config?: { disableAbbreviation?: boolean; verbose?: boolean }) {
     this.disableAbbreviation = config?.disableAbbreviation ?? false
+    this.logger = new Logger(config?.verbose ?? true)
   }
 
   /**
@@ -326,7 +329,7 @@ export class OpenAPISpecLoader {
   ): string | undefined {
     // Handle empty schema (potentially from cycle removal in inlineSchema)
     if (Object.keys(paramSchema).length === 0 && typeof paramSchema !== "boolean") {
-      console.warn(
+      this.logger.warn(
         `Parameter '${paramName}' schema was empty after inlining (potential cycle or unresolvable ref), defaulting to string.`,
       )
       return "string"
@@ -421,19 +424,19 @@ export class OpenAPISpecLoader {
               if (resolvedParam && "name" in resolvedParam && "in" in resolvedParam) {
                 paramObj = resolvedParam as OpenAPIV3.ParameterObject
               } else {
-                console.warn(
+                this.logger.warn(
                   `Could not resolve path-level parameter reference or invalid structure: ${param.$ref}`,
                 )
                 continue
               }
             } else {
-              console.warn(`Could not parse path-level parameter reference: ${param.$ref}`)
+              this.logger.warn(`Could not parse path-level parameter reference: ${param.$ref}`)
               continue
             }
           } else if ("name" in param && "in" in param) {
             paramObj = param as OpenAPIV3.ParameterObject
           } else {
-            console.warn(
+            this.logger.warn(
               "Skipping path-level parameter due to missing 'name' or 'in' properties and not being a valid $ref:",
               param,
             )
@@ -455,7 +458,7 @@ export class OpenAPISpecLoader {
             method.toLowerCase(),
           )
         ) {
-          console.warn(`Skipping non-HTTP method "${method}" for path ${path}`)
+          this.logger.warn(`Skipping non-HTTP method "${method}" for path ${path}`)
           continue
         }
 
@@ -467,7 +470,8 @@ export class OpenAPISpecLoader {
 
         const tool: ExtendedTool = {
           name,
-          description: op.description || op.summary || `Make a ${method.toUpperCase()} request to ${path}`,
+          description:
+            op.description || op.summary || `Make a ${method.toUpperCase()} request to ${path}`,
           inputSchema: {
             type: "object",
             properties: {},
@@ -509,19 +513,19 @@ export class OpenAPISpecLoader {
                 if (resolvedParam && "name" in resolvedParam && "in" in resolvedParam) {
                   paramObj = resolvedParam as OpenAPIV3.ParameterObject
                 } else {
-                  console.warn(
+                  this.logger.warn(
                     `Could not resolve parameter reference or invalid structure: ${param.$ref}`,
                   )
                   continue
                 }
               } else {
-                console.warn(`Could not parse parameter reference: ${param.$ref}`)
+                this.logger.warn(`Could not parse parameter reference: ${param.$ref}`)
                 continue
               }
             } else if ("name" in param && "in" in param) {
               paramObj = param as OpenAPIV3.ParameterObject
             } else {
-              console.warn(
+              this.logger.warn(
                 "Skipping parameter due to missing 'name' or 'in' properties and not being a valid $ref:",
                 param,
               )
@@ -590,19 +594,19 @@ export class OpenAPISpecLoader {
               if (resolvedRequestBody && "content" in resolvedRequestBody) {
                 requestBodyObj = resolvedRequestBody as OpenAPIV3.RequestBodyObject
               } else {
-                console.warn(
+                this.logger.warn(
                   `Could not resolve requestBody reference or invalid structure: ${op.requestBody.$ref}`,
                 )
                 continue
               }
             } else {
-              console.warn(`Could not parse requestBody reference: ${op.requestBody.$ref}`)
+              this.logger.warn(`Could not parse requestBody reference: ${op.requestBody.$ref}`)
               continue
             }
           } else if ("content" in op.requestBody) {
             requestBodyObj = op.requestBody as OpenAPIV3.RequestBodyObject
           } else {
-            console.warn("Skipping requestBody due to invalid structure:", op.requestBody)
+            this.logger.warn("Skipping requestBody due to invalid structure:", op.requestBody)
             continue
           }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { ApiClient, type ApiClientOptions } from "./api-client"
 import { StaticAuthProvider } from "./auth-provider.js"
 import { PromptsManager } from "./prompts-manager"
 import { ResourcesManager } from "./resources-manager"
+import { Logger } from "./utils/logger"
 
 /**
  * MCP server implementation for OpenAPI specifications
@@ -28,9 +29,11 @@ export class OpenAPIServer {
   private promptsManager?: PromptsManager
   private resourcesManager?: ResourcesManager
   private config: OpenAPIMCPServerConfig
+  private logger: Logger
 
   constructor(config: OpenAPIMCPServerConfig) {
     this.config = config
+    this.logger = new Logger(config.verbose)
 
     // Initialize optional managers
     if (config.prompts?.length) {
@@ -140,8 +143,8 @@ export class OpenAPIServer {
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { id, name, arguments: params } = request.params
 
-      console.error("Received request:", request.params)
-      console.error("Using parameters from arguments:", params)
+      this.logger.error("Received request:", request.params)
+      this.logger.error("Using parameters from arguments:", params)
 
       // Find tool by ID or name
       const idOrName = typeof id === "string" ? id : typeof name === "string" ? name : ""
@@ -151,7 +154,7 @@ export class OpenAPIServer {
 
       const toolInfo = this.toolsManager.findTool(idOrName)
       if (!toolInfo) {
-        console.error(
+        this.logger.error(
           `Available tools: ${Array.from(this.toolsManager.getAllTools())
             .map((t) => t.name)
             .join(", ")}`,
@@ -160,7 +163,7 @@ export class OpenAPIServer {
       }
 
       const { toolId, tool } = toolInfo
-      console.error(`Executing tool: ${toolId} (${tool.name})`)
+      this.logger.error(`Executing tool: ${toolId} (${tool.name})`)
 
       try {
         // Execute the API call

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -3,6 +3,7 @@ import { OpenAPISpecLoader, ExtendedTool } from "./openapi-loader"
 import { OpenAPIMCPServerConfig } from "./config"
 import { OpenAPIV3 } from "openapi-types"
 import { parseToolId as parseToolIdUtil } from "./utils/tool-id.js"
+import { Logger } from "./utils/logger"
 
 /**
  * Manages the tools available in the MCP server
@@ -11,13 +12,16 @@ export class ToolsManager {
   private tools: Map<string, Tool> = new Map()
   private specLoader: OpenAPISpecLoader
   private loadedSpec?: OpenAPIV3.Document
+  private logger: Logger
 
   constructor(private config: OpenAPIMCPServerConfig) {
     // Ensure toolsMode has a default value of 'all'
     this.config.toolsMode = this.config.toolsMode || "all"
     this.specLoader = new OpenAPISpecLoader({
       disableAbbreviation: this.config.disableAbbreviation,
+      verbose: this.config.verbose,
     })
+    this.logger = new Logger(this.config.verbose)
   }
 
   /**
@@ -131,7 +135,7 @@ export class ToolsManager {
 
       // Log the registered tools
       for (const [toolId, tool] of this.tools.entries()) {
-        console.error(`Registered tool: ${toolId} (${tool.name})`)
+        this.logger.error(`Registered tool: ${toolId} (${tool.name})`)
       }
       return
     }
@@ -205,7 +209,7 @@ export class ToolsManager {
 
     // Log the registered tools
     for (const [toolId, tool] of this.tools.entries()) {
-      console.error(`Registered tool: ${toolId} (${tool.name})`)
+      this.logger.error(`Registered tool: ${toolId} (${tool.name})`)
     }
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,19 @@
+export class Logger {
+  constructor(private verbose: boolean = true) {}
+
+  setVerbose(verbose: boolean): void {
+    this.verbose = verbose
+  }
+
+  warn(message?: unknown, ...optionalParams: unknown[]): void {
+    if (this.verbose) {
+      console.warn(message, ...optionalParams)
+    }
+  }
+
+  error(message?: unknown, ...optionalParams: unknown[]): void {
+    if (this.verbose) {
+      console.error(message, ...optionalParams)
+    }
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,8 +1,8 @@
 export class Logger {
   constructor(private verbose: boolean = true) {}
 
-  setVerbose(verbose: boolean): void {
-    this.verbose = verbose
+  setVerbose(verbose: boolean | undefined): void {
+    this.verbose = verbose ?? true
   }
 
   warn(message?: unknown, ...optionalParams: unknown[]): void {
@@ -15,5 +15,9 @@ export class Logger {
     if (this.verbose) {
       console.error(message, ...optionalParams)
     }
+  }
+
+  fatal(message?: unknown, ...optionalParams: unknown[]): void {
+    console.error(message, ...optionalParams)
   }
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -104,6 +104,7 @@ describe("loadConfig", () => {
     delete process.env.CA_CERT_PATH
     delete process.env.CLIENT_KEY_PASSPHRASE
     delete process.env.REJECT_UNAUTHORIZED
+    delete process.env.VERBOSE
 
     // Reset mocks before each test
     vi.clearAllMocks()
@@ -174,6 +175,7 @@ describe("loadConfig", () => {
       includeOperations: undefined,
       toolsMode: "all",
       disableAbbreviation: undefined,
+      verbose: true,
     })
   })
 
@@ -244,6 +246,7 @@ describe("loadConfig", () => {
     process.env.SERVER_NAME = "env-server"
     process.env.SERVER_VERSION = "3.2.1"
     process.env.TRANSPORT_TYPE = "stdio"
+    process.env.VERBOSE = "false"
 
     // Import the module after setting up mocks
     const { loadConfig } = await import("../src/config")
@@ -278,6 +281,7 @@ describe("loadConfig", () => {
       includeOperations: undefined,
       toolsMode: "all",
       disableAbbreviation: undefined,
+      verbose: false,
     })
   })
 
@@ -463,7 +467,54 @@ describe("loadConfig", () => {
       includeOperations: undefined,
       toolsMode: "all",
       disableAbbreviation: undefined,
+      verbose: true,
     })
+  })
+
+  it("should disable verbose logging from command line arguments", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({
+          "api-base-url": "https://api.example.com",
+          "openapi-spec": "./spec.json",
+          verbose: false,
+        }),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    const { loadConfig } = await import("../src/config")
+
+    const config = loadConfig()
+    expect(config.verbose).toBe(false)
+  })
+
+  it("should disable verbose logging from environment variables", async () => {
+    vi.doMock("yargs", () => ({
+      default: vi.fn().mockReturnValue({
+        option: vi.fn().mockReturnThis(),
+        help: vi.fn().mockReturnThis(),
+        parseSync: vi.fn().mockReturnValue({}),
+      }),
+    }))
+
+    vi.doMock("yargs/helpers", () => ({
+      hideBin: vi.fn((arr) => arr),
+    }))
+
+    process.env.API_BASE_URL = "https://env.example.com"
+    process.env.OPENAPI_SPEC_PATH = "./env-spec.json"
+    process.env.VERBOSE = "false"
+
+    const { loadConfig } = await import("../src/config")
+
+    const config = loadConfig()
+    expect(config.verbose).toBe(false)
   })
 
   it("should load config with local file spec", async () => {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { Logger } from "../src/utils/logger"
+
+describe("Logger", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it("should suppress warnings when verbose logging is disabled", () => {
+    const logger = new Logger(false)
+
+    logger.warn("warning message")
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("should suppress errors when verbose logging is disabled", () => {
+    const logger = new Logger(false)
+
+    logger.error("error message")
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it("should emit warnings when verbose logging is enabled", () => {
+    const logger = new Logger(true)
+
+    logger.warn("warning message")
+
+    expect(warnSpy).toHaveBeenCalledWith("warning message")
+  })
+
+  it("should emit errors when verbose logging is enabled", () => {
+    const logger = new Logger(true)
+
+    logger.error("error message")
+
+    expect(errorSpy).toHaveBeenCalledWith("error message")
+  })
+})

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -46,4 +46,21 @@ describe("Logger", () => {
 
     expect(errorSpy).toHaveBeenCalledWith("error message")
   })
+
+  it("should always emit fatal errors regardless of verbose mode", () => {
+    const logger = new Logger(false)
+
+    logger.fatal("fatal message")
+
+    expect(errorSpy).toHaveBeenCalledWith("fatal message")
+  })
+
+  it("should default setVerbose(undefined) back to enabled logging", () => {
+    const logger = new Logger(false)
+
+    logger.setVerbose(undefined)
+    logger.error("error message")
+
+    expect(errorSpy).toHaveBeenCalledWith("error message")
+  })
 })


### PR DESCRIPTION
## Summary
- add a `verbose` config option via CLI and environment variables while keeping verbose logging enabled by default for backward compatibility
- route server, transport, tools manager, and OpenAPI loader logs through a shared logger so non-essential stderr output can be suppressed cleanly
- add config/logger regression coverage, update README logging docs, and include the approved OpenSpec change

## Verification
- `npm test -- test/config.test.ts test/logger.test.ts test/server.test.ts test/openapi-loader.test.ts test/tools-manager.test.ts test/transport-http.test.ts test/external-server.test.ts`
- `openspec validate add-configurable-logging --strict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to operational logging output and default to existing behavior, with minimal impact on runtime logic aside from potentially suppressing diagnostics when `verbose` is disabled.
> 
> **Overview**
> Adds configurable operational logging via `--verbose` / `VERBOSE` (default `true`) and introduces a shared `Logger` that can suppress `warn`/`error` output while always emitting `fatal`.
> 
> Wires the logger through CLI startup, `OpenAPIServer`, `ToolsManager`, `OpenAPISpecLoader`, and `StreamableHttpServerTransport`, updates README usage/docs, and adds tests plus OpenSpec change artifacts for the new verbosity requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f32b9579e44608e963380a52b8ec0d913283e1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->