### PR TITLE
feat: support extra custom tools in server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,8 +665,10 @@ const extraTools: ExtraToolDefinition[] = [
         required: ["a", "b"],
       },
     },
-    handler: async ({ a, b }) => {
-      const result = Number(a) + Number(b)
+    handler: async (args) => {
+      const a = Number(args.a)
+      const b = Number(args.b)
+      const result = a + b
       return {
         content: [{ type: "text", text: JSON.stringify({ result }) }],
         structuredContent: { result },

--- a/README.md
+++ b/README.md
@@ -648,9 +648,9 @@ const server = new OpenAPIServer(config)
 You can expose a few hand-written MCP tools alongside the tools generated from your OpenAPI spec:
 
 ```typescript
-import { OpenAPIServer, type ExtraToolDefinition } from "@ivotoby/openapi-mcp-server"
+import { OpenAPIServer } from "@ivotoby/openapi-mcp-server"
 
-const extraTools: ExtraToolDefinition[] = [
+const extraTools = [
   {
     id: "add",
     tool: {

--- a/README.md
+++ b/README.md
@@ -643,6 +643,56 @@ const config = {
 const server = new OpenAPIServer(config)
 ```
 
+### Adding Extra Custom Tools
+
+You can expose a few hand-written MCP tools alongside the tools generated from your OpenAPI spec:
+
+```typescript
+import { OpenAPIServer, type ExtraToolDefinition } from "@ivotoby/openapi-mcp-server"
+
+const extraTools: ExtraToolDefinition[] = [
+  {
+    id: "add",
+    tool: {
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: {
+        type: "object",
+        properties: {
+          a: { type: "number" },
+          b: { type: "number" },
+        },
+        required: ["a", "b"],
+      },
+    },
+    handler: async ({ a, b }) => {
+      const result = Number(a) + Number(b)
+      return {
+        content: [{ type: "text", text: JSON.stringify({ result }) }],
+        structuredContent: { result },
+      }
+    },
+  },
+]
+
+const server = new OpenAPIServer({
+  name: "my-api-server",
+  version: "1.0.0",
+  apiBaseUrl: "https://api.example.com",
+  openApiSpec: "https://api.example.com/openapi.json",
+  specInputMethod: "url",
+  transportType: "stdio",
+  toolsMode: "all",
+  extraTools,
+})
+```
+
+Notes:
+
+- `extraTools` is library-only in this first version; there is no CLI format for function handlers
+- extra tool IDs and MCP tool names must be unique across both custom and OpenAPI-generated tools
+- extra tool handlers should return a normal MCP `tools/call` result object
+
 #### Dynamic Prompt and Resource Management
 
 You can also add prompts and resources dynamically after server creation:

--- a/openspec/changes/add-extra-tools-support/design.md
+++ b/openspec/changes/add-extra-tools-support/design.md
@@ -1,0 +1,41 @@
+## Context
+
+Issue `#62` asks for a way to add custom tools to `OpenAPIServer`. There is already an active broad proposal for custom tools, resources, and prompts, but that scope is large and not needed to deliver the main user value right now.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Add a small, safe extension point for extra custom tools
+  - Preserve current OpenAPI-generated tool behavior
+  - Keep the first implementation config-driven
+- Non-Goals:
+  - Runtime `registerTool()` APIs
+  - Extra custom resources or prompts
+  - Converting OpenAPI output into a standalone SDK tool array API
+
+## Decisions
+
+- Decision: use `extraTools` on `OpenAPIMCPServerConfig` instead of a runtime registration API.
+  - Why: it fits the existing config-driven server construction model and avoids lifecycle issues around registering tools after handlers are installed.
+- Decision: store custom tool definitions separately from OpenAPI-generated tools and merge at the server layer.
+  - Why: `ToolsManager` is currently centered on OpenAPI parsing and filtering; keeping custom dispatch in `OpenAPIServer` reduces churn.
+- Decision: fail fast on duplicate tool IDs or names.
+  - Why: silent shadowing would be hard to debug and unsafe for clients.
+
+## Risks / Trade-offs
+
+- Config-only support is less flexible than `registerTool()`.
+  - Mitigation: keep the internal model clean so a runtime API can be added later if needed.
+- Custom tool handlers need a clear return contract.
+  - Mitigation: require MCP-style tool results and cover it with tests and docs.
+
+## Migration Plan
+
+1. Add typed definitions and config support.
+2. Add server-level dispatch for extra tools.
+3. Keep existing OpenAPI tool execution unchanged.
+4. Document the narrow API and defer broader custom primitive work.
+
+## Open Questions
+
+- None for the first scoped pass.

--- a/openspec/changes/add-extra-tools-support/proposal.md
+++ b/openspec/changes/add-extra-tools-support/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add extra custom tools support
+
+## Why
+
+Library users want to expose a few hand-written MCP tools alongside OpenAPI-generated tools without running multiple servers or reaching into private internals. The current server supports custom prompts and resources through config, but it still lacks a clean extension point for custom tools.
+
+## What Changes
+
+- Add an `extraTools` configuration option for registering custom MCP tools alongside OpenAPI-generated tools
+- Add a typed custom tool handler contract for config-based tool execution
+- Merge extra tools into `tools/list` and dispatch them from `tools/call`
+- Reject ID or name collisions between custom tools and OpenAPI-generated tools
+- Document the config-based API with library usage examples
+
+## Impact
+
+- Affected specs: `extra-tools`
+- Affected code: `src/config.ts`, `src/server.ts`, `src/tools-manager.ts`, new tool type definitions, tests, `README.md`

--- a/openspec/changes/add-extra-tools-support/specs/extra-tools/spec.md
+++ b/openspec/changes/add-extra-tools-support/specs/extra-tools/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Configured extra tools
+
+The OpenAPIServer SHALL allow developers to define extra custom tools in server configuration alongside OpenAPI-generated tools.
+
+#### Scenario: Extra tools appear in tools list
+
+- **WHEN** the server is configured with one or more `extraTools`
+- **THEN** those tools appear in `tools/list` responses alongside generated tools
+
+#### Scenario: Extra tool executes successfully
+
+- **WHEN** an MCP client calls a configured extra tool with valid arguments
+- **THEN** the configured handler is invoked with the provided arguments
+- **AND** the handler result is returned to the client as the tool response
+
+### Requirement: Extra tool collision protection
+
+The OpenAPIServer SHALL reject conflicting extra tool registrations.
+
+#### Scenario: Duplicate extra tool id
+
+- **WHEN** two extra tools use the same configured tool ID
+- **THEN** server initialization fails with a clear error
+
+#### Scenario: Duplicate extra tool name
+
+- **WHEN** two extra tools use the same MCP tool name
+- **THEN** server initialization fails with a clear error
+
+#### Scenario: Conflict with generated tool
+
+- **WHEN** an extra tool uses the ID or name of an OpenAPI-generated tool
+- **THEN** server startup fails with a clear error
+
+### Requirement: Extra tools are configuration-only in the first release
+
+The initial extra tools capability SHALL be exposed through server configuration only.
+
+#### Scenario: Server constructed without extra tools
+
+- **WHEN** the server is created without `extraTools`
+- **THEN** existing OpenAPI-generated tool behavior remains unchanged

--- a/openspec/changes/add-extra-tools-support/tasks.md
+++ b/openspec/changes/add-extra-tools-support/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [x] 1.1 Add typed config support for extra custom tools
+- [x] 1.2 Add failing tests for listing, executing, and validating extra tools
+- [x] 1.3 Implement extra tool registration and execution in `OpenAPIServer`
+- [x] 1.4 Reject collisions with generated tool IDs and names
+- [x] 1.5 Update README with library examples for `extraTools`
+- [x] 1.6 Run targeted verification for config and server behavior

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "module",
   "main": "./dist/bundle.js",
+  "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/ivo-toby/mcp-openapi-server"
@@ -30,7 +31,7 @@
     ]
   },
   "scripts": {
-    "build": "node build.js && chmod +x bin/mcp-server.js",
+    "build": "node build.js && tsc -p tsconfig.build.json && chmod +x bin/mcp-server.js",
     "clean": "rm -rf dist",
     "lint": "eslint --config eslint.config.js src/**/*.ts",
     "lint:fix": "eslint --fix --config eslint.config.js src/**/*.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { AuthProvider } from "./auth-provider.js"
+import type { ExtraToolDefinition } from "./types/extra-tools"
 import type { PromptDefinition } from "./prompt-types"
 import type { ResourceDefinition } from "./resource-types"
 
@@ -49,6 +50,7 @@ export interface OpenAPIMCPServerConfig {
   /** Inline resources JSON content */
   resourcesInline?: string
   verbose?: boolean
+  extraTools?: ExtraToolDefinition[]
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export * from "./prompts-manager"
 export * from "./resources-manager"
 export * from "./prompt-types"
 export * from "./resource-types"
+export * from "./types/extra-tools"
 export * from "./utils/logger"
 
 // Export the main function for programmatic usage

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import { readFileSync } from "node:fs"
 import { Agent as HttpsAgent } from "node:https"
 import {
+  CallToolResult,
   ListToolsRequestSchema,
   CallToolRequestSchema,
   ListPromptsRequestSchema,
@@ -18,6 +19,7 @@ import { StaticAuthProvider } from "./auth-provider.js"
 import { PromptsManager } from "./prompts-manager"
 import { ResourcesManager } from "./resources-manager"
 import { Logger } from "./utils/logger"
+import { ExtraToolDefinition } from "./types/extra-tools"
 
 /**
  * MCP server implementation for OpenAPI specifications
@@ -30,10 +32,13 @@ export class OpenAPIServer {
   private resourcesManager?: ResourcesManager
   private config: OpenAPIMCPServerConfig
   private logger: Logger
+  private extraTools = new Map<string, ExtraToolDefinition>()
+  private extraToolNames = new Map<string, ExtraToolDefinition>()
 
   constructor(config: OpenAPIMCPServerConfig) {
     this.config = config
     this.logger = new Logger(config.verbose)
+    this.registerExtraTools(config.extraTools || [])
 
     // Initialize optional managers
     if (config.prompts?.length) {
@@ -73,6 +78,71 @@ export class OpenAPIServer {
       : new ApiClient(config.apiBaseUrl, authProviderOrHeaders, this.toolsManager.getSpecLoader())
 
     this.initializeHandlers()
+  }
+
+  private registerExtraTools(extraTools: ExtraToolDefinition[]): void {
+    for (const extraTool of extraTools) {
+      if (this.extraTools.has(extraTool.id)) {
+        throw new Error(`Duplicate extra tool id: "${extraTool.id}"`)
+      }
+
+      if (this.extraToolNames.has(extraTool.tool.name)) {
+        throw new Error(`Duplicate extra tool name: "${extraTool.tool.name}"`)
+      }
+
+      this.extraTools.set(extraTool.id, extraTool)
+      this.extraToolNames.set(extraTool.tool.name, extraTool)
+    }
+  }
+
+  private getAllTools(): Tool[] {
+    return [
+      ...this.toolsManager.getAllTools(),
+      ...Array.from(this.extraTools.values(), (tool) => tool.tool),
+    ]
+  }
+
+  private async executeExtraTool(
+    toolIdOrName: string,
+    params: Record<string, unknown>,
+  ): Promise<CallToolResult | undefined> {
+    const extraTool = this.extraTools.get(toolIdOrName) || this.extraToolNames.get(toolIdOrName)
+
+    if (!extraTool) {
+      return undefined
+    }
+
+    this.logger.error(`Executing extra tool: ${extraTool.id} (${extraTool.tool.name})`)
+
+    try {
+      return await extraTool.handler(params)
+    } catch (error) {
+      if (error instanceof Error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: ${error.message}`,
+            },
+          ],
+          isError: true,
+        }
+      }
+
+      throw error
+    }
+  }
+
+  private validateExtraToolConflicts(toolsWithIds: Array<[string, Tool]>): void {
+    for (const [toolId, tool] of toolsWithIds) {
+      if (this.extraTools.has(toolId)) {
+        throw new Error(`Extra tool id conflicts with generated tool id: "${toolId}"`)
+      }
+
+      if (this.extraToolNames.has(tool.name)) {
+        throw new Error(`Extra tool name conflicts with generated tool name: "${tool.name}"`)
+      }
+    }
   }
 
   private createApiClientOptions(): ApiClientOptions | undefined {
@@ -135,7 +205,7 @@ export class OpenAPIServer {
     // Handle tool listing
     this.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
-        tools: this.toolsManager.getAllTools() as any,
+        tools: this.getAllTools() as any,
       }
     })
 
@@ -152,10 +222,18 @@ export class OpenAPIServer {
         throw new Error("Tool ID or name is required")
       }
 
+      const extraToolResult = await this.executeExtraTool(
+        idOrName,
+        (params || {}) as Record<string, unknown>,
+      )
+      if (extraToolResult) {
+        return extraToolResult
+      }
+
       const toolInfo = this.toolsManager.findTool(idOrName)
       if (!toolInfo) {
         this.logger.error(
-          `Available tools: ${Array.from(this.toolsManager.getAllTools())
+          `Available tools: ${Array.from(this.getAllTools())
             .map((t) => t.name)
             .join(", ")}`,
         )
@@ -224,7 +302,10 @@ export class OpenAPIServer {
 
     // Pass the tools to the API client
     const toolsMap = new Map<string, Tool>()
-    for (const [toolId, tool] of this.toolsManager.getToolsWithIds()) {
+    const toolsWithIds = this.toolsManager.getToolsWithIds()
+    this.validateExtraToolConflicts(toolsWithIds)
+
+    for (const [toolId, tool] of toolsWithIds) {
       toolsMap.set(toolId, tool)
     }
     this.apiClient.setTools(toolsMap)

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,8 @@ export class OpenAPIServer {
   private config: OpenAPIMCPServerConfig
   private logger: Logger
   private extraTools = new Map<string, ExtraToolDefinition>()
-  private extraToolNames = new Map<string, ExtraToolDefinition>()
+  private extraToolIdsLower = new Map<string, ExtraToolDefinition>()
+  private extraToolNamesLower = new Map<string, ExtraToolDefinition>()
 
   constructor(config: OpenAPIMCPServerConfig) {
     this.config = config
@@ -82,16 +83,30 @@ export class OpenAPIServer {
 
   private registerExtraTools(extraTools: ExtraToolDefinition[]): void {
     for (const extraTool of extraTools) {
-      if (this.extraTools.has(extraTool.id)) {
+      const normalizedId = extraTool.id.toLowerCase()
+      const normalizedName = extraTool.tool.name.toLowerCase()
+
+      if (this.extraToolIdsLower.has(normalizedId)) {
         throw new Error(`Duplicate extra tool id: "${extraTool.id}"`)
       }
 
-      if (this.extraToolNames.has(extraTool.tool.name)) {
+      if (this.extraToolNamesLower.has(normalizedName)) {
         throw new Error(`Duplicate extra tool name: "${extraTool.tool.name}"`)
       }
 
+      if (this.extraToolNamesLower.has(normalizedId)) {
+        throw new Error(`Extra tool id conflicts with existing extra tool name: "${extraTool.id}"`)
+      }
+
+      if (this.extraToolIdsLower.has(normalizedName)) {
+        throw new Error(
+          `Extra tool name conflicts with existing extra tool id: "${extraTool.tool.name}"`,
+        )
+      }
+
       this.extraTools.set(extraTool.id, extraTool)
-      this.extraToolNames.set(extraTool.tool.name, extraTool)
+      this.extraToolIdsLower.set(normalizedId, extraTool)
+      this.extraToolNamesLower.set(normalizedName, extraTool)
     }
   }
 
@@ -106,7 +121,10 @@ export class OpenAPIServer {
     toolIdOrName: string,
     params: Record<string, unknown>,
   ): Promise<CallToolResult | undefined> {
-    const extraTool = this.extraTools.get(toolIdOrName) || this.extraToolNames.get(toolIdOrName)
+    const normalizedIdOrName = toolIdOrName.toLowerCase()
+    const extraTool =
+      this.extraToolIdsLower.get(normalizedIdOrName) ||
+      this.extraToolNamesLower.get(normalizedIdOrName)
 
     if (!extraTool) {
       return undefined
@@ -135,12 +153,23 @@ export class OpenAPIServer {
 
   private validateExtraToolConflicts(toolsWithIds: Array<[string, Tool]>): void {
     for (const [toolId, tool] of toolsWithIds) {
-      if (this.extraTools.has(toolId)) {
+      const normalizedId = toolId.toLowerCase()
+      const normalizedName = tool.name.toLowerCase()
+
+      if (this.extraToolIdsLower.has(normalizedId)) {
         throw new Error(`Extra tool id conflicts with generated tool id: "${toolId}"`)
       }
 
-      if (this.extraToolNames.has(tool.name)) {
+      if (this.extraToolNamesLower.has(normalizedName)) {
         throw new Error(`Extra tool name conflicts with generated tool name: "${tool.name}"`)
+      }
+
+      if (this.extraToolIdsLower.has(normalizedName)) {
+        throw new Error(`Extra tool id conflicts with generated tool name: "${tool.name}"`)
+      }
+
+      if (this.extraToolNamesLower.has(normalizedId)) {
+        throw new Error(`Extra tool name conflicts with generated tool id: "${toolId}"`)
       }
     }
   }

--- a/src/types/extra-tools.ts
+++ b/src/types/extra-tools.ts
@@ -1,0 +1,7 @@
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js"
+
+export interface ExtraToolDefinition {
+  id: string
+  tool: Tool
+  handler: (args: Record<string, unknown>) => Promise<CallToolResult> | CallToolResult
+}

--- a/test/package-structure.test.ts
+++ b/test/package-structure.test.ts
@@ -58,6 +58,10 @@ describe("Package Structure (Issue #49)", () => {
       expect(packageJson.name).toMatch(/^@[\w-]+\/[\w-]+$/)
     })
 
+    it("should advertise TypeScript declarations for library consumers", () => {
+      expect(packageJson.types).toBe("./dist/index.d.ts")
+    })
+
     it("should have all required fields for npm publishing", () => {
       expect(packageJson.name).toBeDefined()
       expect(packageJson.version).toBeDefined()

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -202,6 +202,8 @@ describe("OpenAPIServer", () => {
       const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
       // @ts-expect-error: access private for test
       const serverMock = serverWithExtraTools.server
+      // @ts-expect-error: access private for test
+      const extraApiClient = serverWithExtraTools.apiClient
       const handler = vi.mocked(serverMock.setRequestHandler).mock.calls[1][1] as any
 
       const result = await handler({ params: { id: "add", arguments: { a: 1, b: 2 } } }, {})
@@ -211,7 +213,7 @@ describe("OpenAPIServer", () => {
         content: [{ type: "text", text: JSON.stringify({ result: 3 }) }],
         structuredContent: { result: 3 },
       })
-      expect(mockApiClient.executeApiCall).not.toHaveBeenCalled()
+      expect(extraApiClient.executeApiCall).not.toHaveBeenCalled()
     })
 
     it("should convert extra tool errors into MCP error results", async () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -152,11 +152,11 @@ describe("OpenAPIServer", () => {
         ],
       }
 
+      vi.mocked(mockServer.setRequestHandler).mockClear()
       const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
       // @ts-expect-error: access private for test
       const serverMock = serverWithExtraTools.server
-      // The shared Server mock records handlers from previous server instances too.
-      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls.at(-2)?.[1] as any
+      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls[0][1] as any
 
       // @ts-expect-error: access private for test
       const toolsManager = serverWithExtraTools.toolsManager
@@ -198,10 +198,11 @@ describe("OpenAPIServer", () => {
         ],
       }
 
+      vi.mocked(mockServer.setRequestHandler).mockClear()
       const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
       // @ts-expect-error: access private for test
       const serverMock = serverWithExtraTools.server
-      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls.at(-1)?.[1] as any
+      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls[1][1] as any
 
       const result = await handler({ params: { id: "add", arguments: { a: 1, b: 2 } } }, {})
 
@@ -229,10 +230,11 @@ describe("OpenAPIServer", () => {
         ],
       }
 
+      vi.mocked(mockServer.setRequestHandler).mockClear()
       const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
       // @ts-expect-error: access private for test
       const serverMock = serverWithExtraTools.server
-      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls.at(-1)?.[1] as any
+      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls[1][1] as any
 
       const result = await handler({ params: { id: "add", arguments: {} } }, {})
 
@@ -283,6 +285,28 @@ describe("OpenAPIServer", () => {
 
       expect(() => new OpenAPIServer(configWithDuplicateNames)).toThrow(
         'Duplicate extra tool name: "add"',
+      )
+    })
+
+    it("should reject extra tool id and name cross-collisions", () => {
+      const configWithCrossCollision: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: { name: "sum", description: "Add", inputSchema: { type: "object" } },
+            handler: vi.fn(),
+          },
+          {
+            id: "sum",
+            tool: { name: "other", description: "Sum", inputSchema: { type: "object" } },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      expect(() => new OpenAPIServer(configWithCrossCollision)).toThrow(
+        'Extra tool id conflicts with existing extra tool name: "sum"',
       )
     })
 
@@ -510,6 +534,111 @@ describe("OpenAPIServer", () => {
             id: "add",
             tool: {
               name: "list-users",
+              description: "Custom users",
+              inputSchema: { type: "object" },
+            },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const toolsManager = serverWithExtraTools.toolsManager
+      vi.mocked(toolsManager.initialize).mockResolvedValue(undefined)
+      vi.mocked(toolsManager.getToolsWithIds).mockReturnValue([
+        ["GET::users", { name: "list-users", inputSchema: { type: "object" } }],
+      ] as any)
+
+      await expect(serverWithExtraTools.start(transport)).rejects.toThrow(
+        'Extra tool name conflicts with generated tool name: "list-users"',
+      )
+    })
+
+    it("should reject extra tool ids that conflict with generated tool names on start", async () => {
+      const transport = {
+        start: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as ServerTransport
+
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "list-users",
+            tool: {
+              name: "custom-users",
+              description: "Custom users",
+              inputSchema: { type: "object" },
+            },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const toolsManager = serverWithExtraTools.toolsManager
+      vi.mocked(toolsManager.initialize).mockResolvedValue(undefined)
+      vi.mocked(toolsManager.getToolsWithIds).mockReturnValue([
+        ["GET::users", { name: "list-users", inputSchema: { type: "object" } }],
+      ] as any)
+
+      await expect(serverWithExtraTools.start(transport)).rejects.toThrow(
+        'Extra tool id conflicts with generated tool name: "list-users"',
+      )
+    })
+
+    it("should reject extra tool names that conflict with generated tool ids on start", async () => {
+      const transport = {
+        start: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as ServerTransport
+
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "custom-users",
+            tool: {
+              name: "GET::users",
+              description: "Custom users",
+              inputSchema: { type: "object" },
+            },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const toolsManager = serverWithExtraTools.toolsManager
+      vi.mocked(toolsManager.initialize).mockResolvedValue(undefined)
+      vi.mocked(toolsManager.getToolsWithIds).mockReturnValue([
+        ["GET::users", { name: "list-users", inputSchema: { type: "object" } }],
+      ] as any)
+
+      await expect(serverWithExtraTools.start(transport)).rejects.toThrow(
+        'Extra tool name conflicts with generated tool id: "GET::users"',
+      )
+    })
+
+    it("should reject case-insensitive conflicts with generated tools on start", async () => {
+      const transport = {
+        start: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as ServerTransport
+
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: {
+              name: "List-Users",
               description: "Custom users",
               inputSchema: { type: "object" },
             },

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -129,6 +129,163 @@ describe("OpenAPIServer", () => {
   })
 
   describe("Tool Execution", () => {
+    it("should include extra tools in tool listing", async () => {
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: {
+              name: "add",
+              description: "Add two numbers",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  a: { type: "number" },
+                  b: { type: "number" },
+                },
+                required: ["a", "b"],
+              },
+            },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const serverMock = serverWithExtraTools.server
+      // The shared Server mock records handlers from previous server instances too.
+      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls.at(-2)?.[1] as any
+
+      // @ts-expect-error: access private for test
+      const toolsManager = serverWithExtraTools.toolsManager
+      vi.mocked(toolsManager.getAllTools).mockReturnValue([
+        { name: "tool1", inputSchema: { type: "object" } },
+      ] as any)
+
+      const result = await handler({}, {})
+      expect(result.tools).toEqual([
+        { name: "tool1", inputSchema: { type: "object" } },
+        expect.objectContaining({ name: "add", description: "Add two numbers" }),
+      ])
+    })
+
+    it("should execute an extra tool by id", async () => {
+      const addHandler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: JSON.stringify({ result: 3 }) }],
+        structuredContent: { result: 3 },
+      })
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: {
+              name: "add",
+              description: "Add two numbers",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  a: { type: "number" },
+                  b: { type: "number" },
+                },
+                required: ["a", "b"],
+              },
+            },
+            handler: addHandler,
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const serverMock = serverWithExtraTools.server
+      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls.at(-1)?.[1] as any
+
+      const result = await handler({ params: { id: "add", arguments: { a: 1, b: 2 } } }, {})
+
+      expect(addHandler).toHaveBeenCalledWith({ a: 1, b: 2 })
+      expect(result).toEqual({
+        content: [{ type: "text", text: JSON.stringify({ result: 3 }) }],
+        structuredContent: { result: 3 },
+      })
+      expect(mockApiClient.executeApiCall).not.toHaveBeenCalled()
+    })
+
+    it("should convert extra tool errors into MCP error results", async () => {
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: {
+              name: "add",
+              description: "Add two numbers",
+              inputSchema: { type: "object" },
+            },
+            handler: vi.fn().mockRejectedValue(new Error("boom")),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const serverMock = serverWithExtraTools.server
+      const handler = vi.mocked(serverMock.setRequestHandler).mock.calls.at(-1)?.[1] as any
+
+      const result = await handler({ params: { id: "add", arguments: {} } }, {})
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Error: boom" }],
+        isError: true,
+      })
+    })
+
+    it("should reject duplicate extra tool ids", () => {
+      const configWithDuplicateIds: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: { name: "add", description: "Add", inputSchema: { type: "object" } },
+            handler: vi.fn(),
+          },
+          {
+            id: "add",
+            tool: { name: "sum", description: "Sum", inputSchema: { type: "object" } },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      expect(() => new OpenAPIServer(configWithDuplicateIds)).toThrow(
+        'Duplicate extra tool id: "add"',
+      )
+    })
+
+    it("should reject duplicate extra tool names", () => {
+      const configWithDuplicateNames: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: { name: "add", description: "Add", inputSchema: { type: "object" } },
+            handler: vi.fn(),
+          },
+          {
+            id: "sum",
+            tool: { name: "add", description: "Sum", inputSchema: { type: "object" } },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      expect(() => new OpenAPIServer(configWithDuplicateNames)).toThrow(
+        'Duplicate extra tool name: "add"',
+      )
+    })
+
     it("should handle tool execution success", async () => {
       const handler = vi.mocked(mockServer.setRequestHandler).mock.calls[1][1]
 
@@ -304,6 +461,76 @@ describe("OpenAPIServer", () => {
   })
 
   describe("Server Lifecycle", () => {
+    it("should reject extra tool ids that conflict with generated tools on start", async () => {
+      const transport = {
+        start: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as ServerTransport
+
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "GET::users",
+            tool: {
+              name: "custom-users",
+              description: "Custom users",
+              inputSchema: { type: "object" },
+            },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const toolsManager = serverWithExtraTools.toolsManager
+      vi.mocked(toolsManager.initialize).mockResolvedValue(undefined)
+      vi.mocked(toolsManager.getToolsWithIds).mockReturnValue([
+        ["GET::users", { name: "list-users", inputSchema: { type: "object" } }],
+      ] as any)
+
+      await expect(serverWithExtraTools.start(transport)).rejects.toThrow(
+        'Extra tool id conflicts with generated tool id: "GET::users"',
+      )
+    })
+
+    it("should reject extra tool names that conflict with generated tools on start", async () => {
+      const transport = {
+        start: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as ServerTransport
+
+      const configWithExtraTools: OpenAPIMCPServerConfig = {
+        ...config,
+        extraTools: [
+          {
+            id: "add",
+            tool: {
+              name: "list-users",
+              description: "Custom users",
+              inputSchema: { type: "object" },
+            },
+            handler: vi.fn(),
+          },
+        ],
+      }
+
+      const serverWithExtraTools = new OpenAPIServer(configWithExtraTools)
+      // @ts-expect-error: access private for test
+      const toolsManager = serverWithExtraTools.toolsManager
+      vi.mocked(toolsManager.initialize).mockResolvedValue(undefined)
+      vi.mocked(toolsManager.getToolsWithIds).mockReturnValue([
+        ["GET::users", { name: "list-users", inputSchema: { type: "object" } }],
+      ] as any)
+
+      await expect(serverWithExtraTools.start(transport)).rejects.toThrow(
+        'Extra tool name conflicts with generated tool name: "list-users"',
+      )
+    })
+
     it("should start the server successfully", async () => {
       vi.mocked(mockToolsManager.initialize).mockResolvedValue(undefined)
       vi.mocked(mockServer.connect).mockResolvedValue(undefined)

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `extraTools` support so library users can expose custom MCP tools alongside OpenAPI-generated tools
- merge extra tools into `tools/list`, execute them from `tools/call`, and reject ID/name collisions with both custom and generated tools
- document the config-only API, add the typed `ExtraToolDefinition` export, and include the approved OpenSpec change

## Verification
- `npm test -- test/server.test.ts test/external-server.test.ts`
- `npm run typecheck`
- `openspec validate add-extra-tools-support --strict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tool-dispatch path in `OpenAPIServer` and enforces collision checks between custom and generated tools, which could affect tool discovery/execution behavior if edge cases were missed.
> 
> **Overview**
> Adds `extraTools` to `OpenAPIMCPServerConfig` so library users can register custom MCP tools (with typed `ExtraToolDefinition` handlers) alongside OpenAPI-generated tools.
> 
> `OpenAPIServer` now merges extra tools into `tools/list`, dispatches them from `tools/call` (including MCP-style error results), and fails fast on case-insensitive ID/name collisions both within `extraTools` and against generated tools at startup. Documentation and exports are updated (`README.md`, `src/index.ts`), and tests cover listing, execution, and conflict validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c48c3e9fdfb72b6314fb96760eaab1bda56481d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->