### PR TITLE
feat: add --exclude-tag filter to exclude tools by OpenAPI tag

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,8 @@ export interface OpenAPIMCPServerConfig {
   includeTools?: string[]
   /** Filter only specific tags */
   includeTags?: string[]
+  /** Filter only no specific tags */
+  excludeTags?: string[]
   /** Filter only specific resources (path prefixes) */
   includeResources?: string[]
   /** Filter only specific HTTP methods: get,post,put,... */
@@ -186,6 +188,11 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       string: true,
       description: "Import only tools with specified OpenAPI tags",
     })
+    .option("exclude-tag", {
+      type: "array",
+      string: true,
+      description: "Import only tools without specified OpenAPI tags",
+    })
     .option("resource", {
       type: "array",
       string: true,
@@ -329,6 +336,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     endpointPath,
     includeTools: argv.tool as string[] | undefined,
     includeTags: argv.tag as string[] | undefined,
+    excludeTags: argv.excludeTag as string[] | undefined,
     includeResources: argv.resource as string[] | undefined,
     includeOperations: argv.operation as string[] | undefined,
     toolsMode,

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -151,6 +151,7 @@ export class ToolsManager {
     const includeResourcesLower =
       this.config.includeResources?.map((res) => res.toLowerCase()) || []
     const includeTagsLower = this.config.includeTags?.map((tag) => tag.toLowerCase()) || []
+    const excludeTagsLower = this.config.excludeTags?.map((tag) => tag.toLowerCase()) || []
 
     for (const [toolId, tool] of rawTools.entries()) {
       const extendedTool = tool as ExtendedTool
@@ -188,6 +189,17 @@ export class ToolsManager {
             ? extendedTool.resourceName.toLowerCase()
             : undefined
         if (!resourceName || !includeResourcesLower.includes(resourceName)) {
+          continue
+        }
+      }
+
+      // noIncludeTags filter
+      if (excludeTagsLower.length > 0) {
+        const toolTags = Array.isArray(extendedTool.tags) ? extendedTool.tags : []
+        const hasMatchingTag = toolTags.some(
+          (tag) => typeof tag === "string" && excludeTagsLower.includes(tag.toLowerCase()),
+        )
+        if (hasMatchingTag) {
           continue
         }
       }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -825,6 +825,7 @@ describe("loadConfig", () => {
             "openapi-spec": "./spec.json",
             tool: ["tool1", "tool2", "tool3"],
             tag: ["auth", "users"],
+            excludeTag: ["products", "orders"],
             resource: ["api/v1/users", "api/v1/posts"],
             operation: ["get", "post", "put"],
           }),
@@ -840,6 +841,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toEqual(["tool1", "tool2", "tool3"])
       expect(config.includeTags).toEqual(["auth", "users"])
+      expect(config.excludeTags).toEqual(["products", "orders"])
       expect(config.includeResources).toEqual(["api/v1/users", "api/v1/posts"])
       expect(config.includeOperations).toEqual(["get", "post", "put"])
     })
@@ -854,6 +856,7 @@ describe("loadConfig", () => {
             "openapi-spec": "./spec.json",
             tool: ["single-tool"],
             tag: ["single-tag"],
+            excludeTag: ["single-tag"],
             resource: ["single-resource"],
             operation: ["get"],
           }),
@@ -869,6 +872,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toEqual(["single-tool"])
       expect(config.includeTags).toEqual(["single-tag"])
+      expect(config.excludeTags).toEqual(["single-tag"])
       expect(config.includeResources).toEqual(["single-resource"])
       expect(config.includeOperations).toEqual(["get"])
     })
@@ -883,6 +887,7 @@ describe("loadConfig", () => {
             "openapi-spec": "./spec.json",
             tool: [],
             tag: [],
+            excludeTag: [],
             resource: [],
             operation: [],
           }),
@@ -898,6 +903,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toEqual([])
       expect(config.includeTags).toEqual([])
+      expect(config.excludeTags).toEqual([])
       expect(config.includeResources).toEqual([])
       expect(config.includeOperations).toEqual([])
     })

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -284,7 +284,7 @@ describe("ToolsManager", () => {
     })
 
     describe("Filter Order of Application", () => {
-      it("should apply filters in the correct order: includeTools -> includeOperations -> includeResources -> includeTags", async () => {
+      it("should apply filters in the correct order: includeTools -> includeOperations -> includeResources -> excludeTags -> includeTags", async () => {
         const mockTools = new Map([
           [
             "GET::users",
@@ -293,6 +293,15 @@ describe("ToolsManager", () => {
               httpMethod: "GET",
               resourceName: "users",
               tags: ["public", "read"],
+            } as ExtendedTool,
+          ],
+          [
+            "GET::adminUsers",
+            {
+              name: "createAdminUsers",
+              httpMethod: "GET",
+              resourceName: "users",
+              tags: ["admin", "read"],
             } as ExtendedTool,
           ],
           [
@@ -331,13 +340,15 @@ describe("ToolsManager", () => {
         // Apply all filters - should work as AND operation
         ;(toolsManager as any).config.includeOperations = ["get", "post"] // Excludes DELETE
         ;(toolsManager as any).config.includeResources = ["users"] // Excludes orders
+        ;(toolsManager as any).config.excludeTags = ["write"] // Exludes write tools
         ;(toolsManager as any).config.includeTags = ["public"] // Excludes admin-only tools
 
         await toolsManager.initialize()
 
         // Only GET::users should match all criteria:
-        // - Operation: GET (✓) or POST (✗ - has admin tag, not public)
+        // - Operation: GET (✓) or POST (✗ - has admin tag, not public, not write)
         // - Resource: users (✓)
+        // - ExcludeTags: write (✓)
         // - Tags: public (✓)
         const resultToolIds = Array.from((toolsManager as any).tools.keys())
         expect(resultToolIds).toEqual(["GET::users"])
@@ -373,6 +384,7 @@ describe("ToolsManager", () => {
         ;(toolsManager as any).config.includeTools = ["DELETE::orders-id"] // Explicitly include this tool
         ;(toolsManager as any).config.includeOperations = ["get"] // Would normally exclude DELETE
         ;(toolsManager as any).config.includeResources = ["users"] // Would normally exclude orders
+        ;(toolsManager as any).config.excludeTags = ["admin"] // Would normally exclude admin
         ;(toolsManager as any).config.includeTags = ["public"] // Would normally exclude admin
 
         await toolsManager.initialize()
@@ -412,6 +424,7 @@ describe("ToolsManager", () => {
         ;(toolsManager as any).config.includeTools = []
         ;(toolsManager as any).config.includeOperations = []
         ;(toolsManager as any).config.includeResources = []
+        ;(toolsManager as any).config.excludeTags = []
         ;(toolsManager as any).config.includeTags = []
 
         await toolsManager.initialize()


### PR DESCRIPTION
### **feat: add --exclude-tag option to filter out tools by OpenAPI tag**

Adds a new --exclude-tag CLI option that allows excluding tools that contain specific OpenAPI tags, complementing the existing --tag (include) filter.

### **Changes:**

`config.ts`: added excludeTags field to `OpenAPIMCPServerConfig` interface and --exclude-tag CLI option parsed via yargs camelCase `(argv.excludeTag)`
_tools-manager.ts_: added excludeTags filter logic applied before includeTags, skipping tools that match any excluded tag
`test/config.test.ts`: added coverage for excludeTags in single, multiple, and empty value scenarios
`test/tools-manager.test.ts`: updated filter order test to include excludeTags in the chain and fixed duplicate map key that was causing a tool to be silently overwritten

Filter order: includeTools → includeOperations → includeResources → excludeTags → includeTags