### PR TITLE
Fix CLI version and unknown option handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
-import packageJson from "../package.json" with { type: "json" }
+import packageJson from "../package.json"
 import { AuthProvider } from "./auth-provider.js"
 import type { PromptDefinition } from "./prompt-types"
 import type { ResourceDefinition } from "./resource-types"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
+import packageJson from "../package.json" with { type: "json" }
 import { AuthProvider } from "./auth-provider.js"
 import type { PromptDefinition } from "./prompt-types"
 import type { ResourceDefinition } from "./resource-types"
@@ -219,6 +220,11 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     .option("verbose", {
       type: "string",
       description: "Enable verbose logging",
+    })
+    .version(packageJson.version)
+    .strictOptions()
+    .fail((message, error) => {
+      throw new Error(message || error?.message)
     })
     .help()
     .parseSync()

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,11 @@ async function main(): Promise<void> {
       logger.error("OpenAPI MCP Server running on stdio")
     }
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unknown argument")) {
+      logger.fatal(error.message)
+      process.exit(1)
+    }
+
     logger.fatal("Failed to start server:", error)
     process.exit(1)
   }

--- a/test/cli-execution.test.ts
+++ b/test/cli-execution.test.ts
@@ -103,6 +103,67 @@ describe("CLI Execution", () => {
     })
   }, 10000)
 
+  it("prints the package version for --version", async () => {
+    const cliPath = join(__dirname, "..", "dist", "cli.js")
+
+    const child = spawn("node", [cliPath, "--version"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        NODE_ENV: "test",
+      },
+    })
+
+    let stdout = ""
+
+    child.stdout.on("data", (data) => {
+      stdout += data.toString()
+    })
+
+    return new Promise<void>((resolve, reject) => {
+      child.on("exit", (code) => {
+        expect(code).toBe(0)
+        expect(stdout.trim()).toBe("0.1.0")
+        resolve()
+      })
+
+      child.on("error", reject)
+    })
+  })
+
+  it("rejects unknown top-level flags before config validation", async () => {
+    const cliPath = join(__dirname, "..", "dist", "cli.js")
+
+    const child = spawn("node", [cliPath, "--definitely-not-a-real-flag"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        NODE_ENV: "test",
+      },
+    })
+
+    let stderr = ""
+
+    child.stderr.on("data", (data) => {
+      stderr += data.toString()
+    })
+
+    return new Promise<void>((resolve, reject) => {
+      child.on("exit", (code) => {
+        try {
+          expect(code).not.toBe(0)
+          expect(stderr).toContain("Unknown arguments: definitely-not-a-real-flag")
+          expect(stderr).not.toContain("OpenAPI spec is required")
+          resolve()
+        } catch (error) {
+          reject(error)
+        }
+      })
+
+      child.on("error", reject)
+    })
+  })
+
   it("should be executable when imported as library without auto-starting", async () => {
     // This test ensures that importing the main module doesn't auto-start the server
     const { main } = await import("../src/index.js")

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -127,6 +127,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -185,6 +188,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "openapi-spec": "./spec.json",
         }),
@@ -207,6 +213,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
         }),
@@ -229,6 +238,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           // empty object
         }),
@@ -291,6 +303,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -317,6 +332,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -342,6 +360,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -369,6 +390,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -396,6 +420,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -419,6 +446,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "https://api.example.com/openapi.json",
@@ -476,6 +506,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -499,6 +532,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({}),
       }),
     }))
@@ -522,6 +558,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -545,6 +584,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -576,6 +618,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -599,6 +644,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({}),
       }),
     }))
@@ -630,6 +678,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({}),
       }),
     }))
@@ -653,6 +704,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({}),
       }),
     }))
@@ -675,6 +729,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "spec-from-stdin": true,
@@ -701,6 +758,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "spec-inline": inlineSpec,
@@ -725,6 +785,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({}),
       }),
     }))
@@ -750,6 +813,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({}),
       }),
     }))
@@ -773,6 +839,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
         }),
@@ -795,6 +864,9 @@ describe("loadConfig", () => {
       default: vi.fn().mockReturnValue({
         option: vi.fn().mockReturnThis(),
         help: vi.fn().mockReturnThis(),
+        version: vi.fn().mockReturnThis(),
+        strictOptions: vi.fn().mockReturnThis(),
+        fail: vi.fn().mockReturnThis(),
         parseSync: vi.fn().mockReturnValue({
           "api-base-url": "https://api.example.com",
           "openapi-spec": "./spec.json",
@@ -820,6 +892,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -849,6 +924,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -878,6 +956,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -907,6 +988,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -936,6 +1020,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -958,6 +1045,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -982,6 +1072,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1004,6 +1097,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1027,6 +1123,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1050,6 +1149,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1073,6 +1175,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1095,6 +1200,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1118,6 +1226,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1141,6 +1252,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1162,6 +1276,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1185,6 +1302,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1214,6 +1334,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1243,6 +1366,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",
@@ -1269,6 +1395,9 @@ describe("loadConfig", () => {
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
           help: vi.fn().mockReturnThis(),
+          version: vi.fn().mockReturnThis(),
+          strictOptions: vi.fn().mockReturnThis(),
+          fail: vi.fn().mockReturnThis(),
           parseSync: vi.fn().mockReturnValue({
             "api-base-url": "https://api.example.com",
             "openapi-spec": "./spec.json",


### PR DESCRIPTION
## Summary
- wire the CLI `--version` output to the package metadata instead of yargs fallback/defaults
- reject unknown top-level options before config validation reaches the OpenAPI spec requirement
- keep existing `--help` behavior unchanged

Fixes #90

## Verification
- `node build.js`
- `npm test -- --run test/cli-execution.test.ts`
- `node dist/cli.js --version`
- `node dist/cli.js --definitely-not-a-real-flag`