### PR TITLE
[codex] Add exclude-tag filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ npx @ivotoby/openapi-mcp-server \
   --api-base-url https://api.example.com \
   --openapi-spec https://api.example.com/openapi.json \
   --headers "Authorization:Bearer token123,X-API-Key:your-api-key" \
+  --exclude-tag admin \
   --client-cert ./certs/client.pem \
   --client-key ./certs/client-key.pem \
   --name "my-mcp-server" \
@@ -300,12 +301,15 @@ Based on the Stainless article "What We Learned Converting Complex OpenAPI Specs
 
 - `--tools <all|dynamic|explicit>`: Choose tool loading mode:
   - `all` (default): Load all tools from the OpenAPI spec, applying any specified filters
-  - `dynamic`: Load only dynamic meta-tools (`list-api-endpoints`, `get-api-endpoint-schema`, `invoke-api-endpoint`)
-  - `explicit`: Load only tools explicitly listed in `--tool` options, ignoring all other filters
-- `--tool <toolId>`: Import only specified tool IDs or names. Can be used multiple times.
+  - `dynamic`: Load only dynamic meta-tools (`list-api-endpoints`, `get-api-endpoint-schema`, `invoke-api-endpoint`). `--exclude-tag` still applies to dynamic endpoint discovery and invocation.
+  - `explicit`: Load only tools explicitly listed in `--tool` options, ignoring include filters. `--exclude-tag` still applies as a deny filter.
+- `--tool <toolId>`: Import only specified tool IDs or names. Can be used multiple times. In `all` mode, this bypasses `--tag`, `--resource`, and `--operation`, but not `--exclude-tag`.
 - `--tag <tag>`: Import only tools with the specified OpenAPI tag. Can be used multiple times.
+- `--exclude-tag <tag>`: Exclude tools with the specified OpenAPI tag. Can be used multiple times. Excluded tags take precedence over `--tool`.
 - `--resource <resource>`: Import only tools under the specified resource path prefixes. Can be used multiple times.
 - `--operation <method>`: Import only tools for the specified HTTP methods (get, post, etc). Can be used multiple times.
+
+Tag filters are tool-surface controls, not authorization. Keep protecting sensitive endpoints with the upstream API's auth model. Untagged endpoints are not affected by `--exclude-tag`.
 
 **Examples:**
 
@@ -321,6 +325,9 @@ npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi
 
 # Load tools tagged with "user" under the "/users" resource
 npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --tag user --resource users
+
+# Exclude admin and internal endpoints from any tool loading mode
+npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --exclude-tag admin --exclude-tag internal
 
 # Load only POST operations
 npx @ivotoby/openapi-mcp-server --api-base-url https://api.example.com --openapi-spec https://api.example.com/openapi.json --operation post
@@ -577,6 +584,7 @@ const config = {
   // Optional: Apply filters to control which tools are loaded
   includeTools: ["GET::users", "POST::users"], // Only these tools
   includeTags: ["public"], // Only tools with these tags
+  excludeTags: ["admin", "internal"], // Never expose tools with these tags
   includeResources: ["users"], // Only tools under these resources
   includeOperations: ["get", "post"], // Only these HTTP methods
 }
@@ -586,13 +594,15 @@ const config = {
   // ... other config
   toolsMode: "dynamic" as const,
   // Provides: list-api-endpoints, get-api-endpoint-schema, invoke-api-endpoint
+  // excludeTags still hides matching operations from discovery and invocation
 }
 
-// Load only explicitly specified tools (ignores other filters)
+// Load only explicitly specified tools (include filters are ignored)
 const config = {
   // ... other config
   toolsMode: "explicit" as const,
   includeTools: ["GET::users", "POST::users"], // Only these exact tools
+  excludeTags: ["admin"], // Still applied as a deny filter
   // includeTags, includeResources, includeOperations are ignored in explicit mode
 }
 ```
@@ -932,10 +942,24 @@ The MCP server handles various OpenAPI schema complexities:
 
 - `npm run build` - Builds the TypeScript source
 - `npm run clean` - Removes build artifacts
+- `npm test` - Runs the Vitest test suite
 - `npm run typecheck` - Runs TypeScript type checking
-- `npm run lint` - Runs ESLint
+- `npm run lint` - Runs type-aware ESLint against `src/**/*.ts`
 - `npm run dev` - Watches source files and rebuilds on changes
 - `npm run inspect-watch` - Runs the inspector with auto-reload on changes
+
+### Verification Before Pull Requests
+
+Run the full local verification suite before opening a PR:
+
+```bash
+npm run build
+npm test
+npm run typecheck
+npm run lint
+```
+
+`npm run build` refreshes `dist/` so CLI execution tests use current code. `npm run lint` is intentionally type-aware and should be clean for all source files.
 
 ### Development Workflow
 
@@ -950,7 +974,7 @@ The MCP server handles various OpenAPI schema complexities:
 1. Fork the repository
 2. Create a feature branch
 3. Make your changes
-4. Run tests and linting: `npm run typecheck && npm run lint`
+4. Run build, tests, typecheck, and linting: `npm run build && npm test && npm run typecheck && npm run lint`
 5. Submit a pull request
 
 **📖 For comprehensive developer documentation, see [docs/developer-guide.md](./docs/developer-guide.md)**
@@ -975,7 +999,7 @@ A: Use the `AuthProvider` interface instead of static headers. AuthProvider allo
 A: `AuthProvider` is an interface for dynamic authentication that gets fresh headers before each request and handles authentication errors. Use it when your API has expiring tokens, requires token refresh, or needs complex authentication logic that static headers can't handle.
 
 **Q: How do I filter which tools are loaded?**
-A: Use the `--tool`, `--tag`, `--resource`, and `--operation` flags with `--tools all` (default), set `--tools dynamic` for meta-tools only, or use `--tools explicit` to load only tools specified with `--tool` (ignoring other filters).
+A: Use the `--tool`, `--tag`, `--exclude-tag`, `--resource`, and `--operation` flags with `--tools all` (default), set `--tools dynamic` for meta-tools only, or use `--tools explicit` to load only tools specified with `--tool`. `--exclude-tag` is a deny filter and still applies in dynamic and explicit modes.
 
 **Q: When should I use dynamic mode?**
 A: Dynamic mode provides meta-tools (`list-api-endpoints`, `get-api-endpoint-schema`, `invoke-api-endpoint`) to inspect and interact with endpoints without preloading all operations, which is useful for large or changing APIs.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -256,10 +256,13 @@ private extractResourceName(path: string): string | undefined {
 
 Filters are applied in a specific order with different precedence:
 
-1. **`includeTools`** (highest priority): If specified, overrides all other filters
-2. **`includeOperations`**: Filter by HTTP methods (AND operation with remaining filters)
-3. **`includeResources`**: Filter by resource names (AND operation)
-4. **`includeTags`**: Filter by OpenAPI tags (AND operation)
+1. **`excludeTags`** (hard deny): If a tool has any excluded OpenAPI tag, it is removed before include filters are applied.
+2. **`includeTools`**: If specified, selects only matching tool IDs or names after excluded tags have been removed, then bypasses the remaining include filters.
+3. **`includeOperations`**: When `includeTools` is not set, filter by HTTP methods (AND operation with remaining filters)
+4. **`includeResources`**: When `includeTools` is not set, filter by resource names (AND operation)
+5. **`includeTags`**: When `includeTools` is not set, filter by OpenAPI tags (AND operation)
+
+`excludeTags` is a tool-surface filter, not an authorization mechanism. Untagged endpoints pass the exclude filter, so sensitive operations still need upstream API authorization and correct OpenAPI tags.
 
 ### Filter Modes
 
@@ -267,7 +270,7 @@ Filters are applied in a specific order with different precedence:
 
 ```typescript
 toolsMode: "all"
-// Apply filters as AND operations
+// Apply filters as AND operations after excludeTags removes denied tools
 // Empty filter arrays = no filtering for that dimension
 ```
 
@@ -277,7 +280,8 @@ toolsMode: "all"
 toolsMode: "explicit"
 includeTools: ["GET::users", "POST::users"]
 // ONLY load explicitly listed tools
-// Ignore all other filters
+// Ignore includeTags, includeResources, and includeOperations
+// Still apply excludeTags as a deny filter
 ```
 
 #### Dynamic Mode
@@ -288,6 +292,7 @@ toolsMode: "dynamic"
 // - list-api-endpoints
 // - get-api-endpoint-schema
 // - invoke-api-endpoint
+// excludeTags filters discovery responses and blocks matching dynamic invocations
 ```
 
 ### Case Sensitivity

--- a/openspec/changes/add-exclude-tag-filter/design.md
+++ b/openspec/changes/add-exclude-tag-filter/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The existing filtering model narrows endpoint-based tools in `ToolsManager` for `toolsMode: "all"` and treats `includeTools` as the highest-precedence allow-list. Dynamic mode is different: it exposes meta-tools that inspect and invoke operations directly from the loaded OpenAPI document.
+
+## Goals / Non-Goals
+
+- Goal: provide a case-insensitive OpenAPI tag deny-list for the MCP tool surface.
+- Goal: avoid surprising fail-open behavior when `excludeTags` is combined with `includeTools`, explicit mode, or dynamic mode.
+- Goal: keep the feature small and consistent with existing filter patterns.
+- Non-goal: implement authorization. Excluded endpoints must still be protected by the upstream API.
+
+## Decisions
+
+- Decision: `excludeTags` wins over `includeTools`. Explicitly including an excluded endpoint should not surface it.
+- Decision: explicit mode still uses `includeTools` to define the candidate set, then applies `excludeTags` as a final deny filter.
+- Decision: dynamic mode passes excluded tags into `ApiClient`, which filters endpoint listing/schema responses and rejects invocation of excluded operations.
+- Alternative considered: reject `excludeTags` in dynamic and explicit modes. This is simpler but less useful because dynamic mode is where large specs benefit most from tag pruning.
+
+## Risks / Trade-offs
+
+- Risk: Users may confuse tag filtering with security authorization. Mitigation: document it as MCP tool-surface filtering only.
+- Risk: Untagged dangerous endpoints cannot be excluded by tag. Mitigation: document that exclusion depends on correct OpenAPI tagging.
+- Trade-off: Dynamic mode needs a small amount of operation-tag lookup in `ApiClient`, but that keeps behavior consistent across modes.
+
+## Migration Plan
+
+Existing configurations continue to behave the same unless `excludeTags` or `--exclude-tag` is set.

--- a/openspec/changes/add-exclude-tag-filter/proposal.md
+++ b/openspec/changes/add-exclude-tag-filter/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add exclude-tag filtering
+
+## Why
+
+Large OpenAPI specs often include admin, internal, deprecated, or otherwise noisy endpoint groups that should not be exposed to an LLM tool surface by default. Operators need a simple deny-list filter that removes endpoints by OpenAPI tag without maintaining a long explicit allow-list.
+
+## What Changes
+
+- Add `excludeTags` configuration and a `--exclude-tag` CLI option.
+- Treat excluded tags as a hard tool-surface deny across all, explicit, and dynamic tool modes.
+- Ensure dynamic meta-tools do not list, describe, or invoke excluded endpoints.
+- Document that tag exclusion reduces the MCP tool surface but does not replace upstream authorization.
+
+## Impact
+
+- Affected specs: tool-filtering
+- Affected code: `src/config.ts`, `src/tools-manager.ts`, `src/api-client.ts`
+- Affected tests: `test/config.test.ts`, `test/tools-manager.test.ts`, `test/api-client.test.ts`

--- a/openspec/changes/add-exclude-tag-filter/specs/tool-filtering/spec.md
+++ b/openspec/changes/add-exclude-tag-filter/specs/tool-filtering/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Exclude Tag Filtering
+
+The system SHALL allow operators to configure OpenAPI tags that are excluded from the exposed MCP tool surface.
+
+#### Scenario: Endpoint tool with excluded tag
+
+- **WHEN** an OpenAPI operation has a tag matching an excluded tag case-insensitively
+- **THEN** the corresponding endpoint tool is not listed or callable through the generated endpoint-tool registry
+
+#### Scenario: Explicit include conflicts with excluded tag
+
+- **WHEN** an endpoint is selected by `includeTools` and also has a matching excluded tag
+- **THEN** the endpoint remains excluded
+
+#### Scenario: Dynamic endpoint listing
+
+- **WHEN** dynamic mode lists or describes endpoints
+- **THEN** operations with matching excluded tags are omitted from dynamic discovery responses
+
+#### Scenario: Dynamic endpoint invocation
+
+- **WHEN** dynamic mode attempts to invoke an operation with a matching excluded tag
+- **THEN** the invocation is rejected before the upstream API request is made
+
+#### Scenario: Untagged endpoint
+
+- **WHEN** an operation has no tags
+- **THEN** exclude-tag filtering does not exclude it

--- a/openspec/changes/add-exclude-tag-filter/tasks.md
+++ b/openspec/changes/add-exclude-tag-filter/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] 1.1 Add configuration support for `excludeTags` and `--exclude-tag`.
+- [x] 1.2 Add `ToolsManager` tests proving excluded tags are removed in all and explicit modes, including conflicts with `includeTools`.
+- [x] 1.3 Implement `ToolsManager` deny-filter behavior.
+- [x] 1.4 Add `ApiClient` tests proving dynamic meta-tools hide and reject excluded operations.
+- [x] 1.5 Implement dynamic meta-tool exclude-tag behavior.
+- [x] 1.6 Update README and developer guide filtering docs.
+- [x] 1.7 Run focused tests, typecheck, build, and broader verification.
+- [x] 1.8 Fix repository lint failures and document PR verification commands in README.

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -34,6 +34,7 @@ export class ApiClient {
   private authProvider: AuthProvider
   private specLoader?: OpenAPISpecLoader
   private openApiSpec?: OpenAPIV3.Document
+  private excludeTagsLower: string[]
 
   /**
    * Create a new API client
@@ -73,6 +74,25 @@ export class ApiClient {
     }
 
     this.specLoader = specLoader
+    this.excludeTagsLower = options?.excludeTags?.map((tag) => tag.toLowerCase()) || []
+  }
+
+  private operationHasExcludedTag(operation: unknown): boolean {
+    if (
+      this.excludeTagsLower.length === 0 ||
+      !operation ||
+      typeof operation !== "object" ||
+      "$ref" in operation
+    ) {
+      return false
+    }
+
+    const tags = Array.isArray((operation as { tags?: unknown }).tags)
+      ? (operation as { tags: unknown[] }).tags
+      : []
+    return tags.some(
+      (tag) => typeof tag === "string" && this.excludeTagsLower.includes(tag.toLowerCase()),
+    )
   }
 
   /**
@@ -461,6 +481,10 @@ export class ApiClient {
           }
 
           const op = operation as any
+          if (this.operationHasExcludedTag(operation)) {
+            continue
+          }
+
           endpoints.push({
             method: method.toUpperCase(),
             path,
@@ -536,6 +560,10 @@ export class ApiClient {
         }
 
         const op = operation as any
+        if (this.operationHasExcludedTag(operation)) {
+          continue
+        }
+
         operations.push({
           method: method.toUpperCase(),
           operationId: op.operationId || "",
@@ -611,7 +639,14 @@ export class ApiClient {
       } else if (this.openApiSpec) {
         // Check if the endpoint and method exist in the OpenAPI spec
         const pathItem = this.openApiSpec.paths[endpoint]
-        if (pathItem && (pathItem as any)[method.toLowerCase()]) {
+        const operation = pathItem ? (pathItem as any)[method.toLowerCase()] : undefined
+        if (pathItem && operation) {
+          if (this.operationHasExcludedTag(operation)) {
+            throw new Error(
+              `Endpoint '${endpoint}' with method '${method.toUpperCase()}' is excluded by tag filter`,
+            )
+          }
+
           // Make the HTTP request directly since we have the spec but not the tool
           const { method: httpMethod, path } = { method: method.toUpperCase(), path: endpoint }
           return this.makeDirectHttpRequest(httpMethod, path, endpointParams)
@@ -631,7 +666,8 @@ export class ApiClient {
       if (pathItem) {
         // Find the first available HTTP method for this path
         for (const method of VALID_HTTP_METHODS) {
-          if ((pathItem as any)[method]) {
+          const operation = (pathItem as any)[method]
+          if (operation && !this.operationHasExcludedTag(operation)) {
             return this.makeDirectHttpRequest(method.toUpperCase(), endpoint, endpointParams)
           }
         }
@@ -699,5 +735,6 @@ export class ApiClient {
 }
 
 export interface ApiClientOptions {
+  excludeTags?: string[]
   httpsAgent?: HttpsAgent
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,8 @@ export interface OpenAPIMCPServerConfig {
   includeTools?: string[]
   /** Filter only specific tags */
   includeTags?: string[]
+  /** Exclude tools tagged with any of these OpenAPI tags */
+  excludeTags?: string[]
   /** Filter only specific resources (path prefixes) */
   includeResources?: string[]
   /** Filter only specific HTTP methods: get,post,put,... */
@@ -188,6 +190,11 @@ export function loadConfig(): OpenAPIMCPServerConfig {
       string: true,
       description: "Import only tools with specified OpenAPI tags",
     })
+    .option("exclude-tag", {
+      type: "array",
+      string: true,
+      description: "Exclude tools tagged with any of these OpenAPI tags",
+    })
     .option("resource", {
       type: "array",
       string: true,
@@ -331,6 +338,7 @@ export function loadConfig(): OpenAPIMCPServerConfig {
     endpointPath,
     includeTools: argv.tool as string[] | undefined,
     includeTags: argv.tag as string[] | undefined,
+    excludeTags: argv.excludeTag as string[] | undefined,
     includeResources: argv.resource as string[] | undefined,
     includeOperations: argv.operation as string[] | undefined,
     toolsMode,

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,15 +68,14 @@ export class OpenAPIServer {
 
     // Use AuthProvider if provided, otherwise fallback to static headers
     const authProviderOrHeaders = config.authProvider || new StaticAuthProvider(config.headers)
-    const apiClientOptions = this.createApiClientOptions()
-    this.apiClient = apiClientOptions
-      ? new ApiClient(
-          config.apiBaseUrl,
-          authProviderOrHeaders,
-          this.toolsManager.getSpecLoader(),
-          apiClientOptions,
-        )
-      : new ApiClient(config.apiBaseUrl, authProviderOrHeaders, this.toolsManager.getSpecLoader())
+    const apiClientOptions: ApiClientOptions = this.createApiClientOptions() || {}
+    apiClientOptions.excludeTags = config.excludeTags
+    this.apiClient = new ApiClient(
+      config.apiBaseUrl,
+      authProviderOrHeaders,
+      this.toolsManager.getSpecLoader(),
+      apiClientOptions,
+    )
 
     this.initializeHandlers()
   }

--- a/src/tools-manager.ts
+++ b/src/tools-manager.ts
@@ -24,6 +24,15 @@ export class ToolsManager {
     this.logger = new Logger(this.config.verbose)
   }
 
+  private toolHasMatchingTag(tool: ExtendedTool, tagsLower: string[]): boolean {
+    if (tagsLower.length === 0) {
+      return false
+    }
+
+    const toolTags = Array.isArray(tool.tags) ? tool.tags : []
+    return toolTags.some((tag) => typeof tag === "string" && tagsLower.includes(tag.toLowerCase()))
+  }
+
   /**
    * Get the OpenAPI spec loader instance
    */
@@ -112,11 +121,13 @@ export class ToolsManager {
       // Only load tools explicitly listed in includeTools
       const rawTools = this.specLoader.parseOpenAPISpec(spec)
       const filtered = new Map<string, Tool>()
+      const excludeTagsLower = this.config.excludeTags?.map((tag) => tag.toLowerCase()) || []
 
       if (this.config.includeTools && this.config.includeTools.length > 0) {
         const includeToolsLower = this.config.includeTools.map((t) => t.toLowerCase())
 
         for (const [toolId, tool] of rawTools.entries()) {
+          const extendedTool = tool as ExtendedTool
           const toolIdLower = toolId.toLowerCase()
           const toolNameLower = tool.name.toLowerCase()
 
@@ -125,6 +136,9 @@ export class ToolsManager {
             includeToolsLower.includes(toolIdLower) ||
             includeToolsLower.includes(toolNameLower)
           ) {
+            if (this.toolHasMatchingTag(extendedTool, excludeTagsLower)) {
+              continue
+            }
             filtered.set(toolId, tool)
           }
         }
@@ -151,9 +165,15 @@ export class ToolsManager {
     const includeResourcesLower =
       this.config.includeResources?.map((res) => res.toLowerCase()) || []
     const includeTagsLower = this.config.includeTags?.map((tag) => tag.toLowerCase()) || []
+    const excludeTagsLower = this.config.excludeTags?.map((tag) => tag.toLowerCase()) || []
 
     for (const [toolId, tool] of rawTools.entries()) {
       const extendedTool = tool as ExtendedTool
+
+      // excludeTags filter - always wins over include filters
+      if (this.toolHasMatchingTag(extendedTool, excludeTagsLower)) {
+        continue
+      }
 
       // includeTools filter - takes highest priority
       if (includeToolsLower.length > 0) {
@@ -194,11 +214,7 @@ export class ToolsManager {
 
       // includeTags filter
       if (includeTagsLower.length > 0) {
-        const toolTags = Array.isArray(extendedTool.tags) ? extendedTool.tags : []
-        const hasMatchingTag = toolTags.some(
-          (tag) => typeof tag === "string" && includeTagsLower.includes(tag.toLowerCase()),
-        )
-        if (!hasMatchingTag) {
+        if (!this.toolHasMatchingTag(extendedTool, includeTagsLower)) {
           continue
         }
       }

--- a/src/transport/StreamableHttpServerTransport.ts
+++ b/src/transport/StreamableHttpServerTransport.ts
@@ -162,7 +162,7 @@ export class StreamableHttpServerTransport implements Transport {
    *
    * @param message JSON-RPC message
    */
-  async send(message: JSONRPCMessage): Promise<void> {
+  send(message: JSONRPCMessage): Promise<void> {
     this.logger.error(`StreamableHttpServerTransport: Sending message: ${JSON.stringify(message)}`)
     let targetSessionId: string | undefined
     let messageIdForThisResponse: string | number | null = null
@@ -187,7 +187,7 @@ export class StreamableHttpServerTransport implements Transport {
           this.logger.error(
             `StreamableHttpServerTransport: Response for ID ${messageIdForThisResponse} was handled by an initResponseHandler (e.g., synchronous POST response for initialize or tools/list).`,
           )
-          return // Exit, as response was sent on POST by the handler.
+          return Promise.resolve() // Exit, as response was sent on POST by the handler.
         } else {
           this.logger.error(
             `StreamableHttpServerTransport: Response for ID ${messageIdForThisResponse} was NOT exclusively handled by an initResponseHandler or handler did not remove from requestSessionMap. Proceeding to GET stream / broadcast if applicable.`,
@@ -226,7 +226,7 @@ export class StreamableHttpServerTransport implements Transport {
           this.sendMessageToSession(sid, session, message)
         }
       }
-      return
+      return Promise.resolve()
     }
 
     // If targetSessionId is known (it's a response to a request that was not handled synchronously by initResponseHandler)
@@ -243,6 +243,8 @@ export class StreamableHttpServerTransport implements Transport {
         `StreamableHttpServerTransport: No active GET connections for session ${targetSessionId} to send message (ID: ${messageIdForThisResponse}). Message might not be delivered if not handled by POST.`,
       )
     }
+
+    return Promise.resolve()
   }
 
   /**
@@ -410,8 +412,8 @@ export class StreamableHttpServerTransport implements Transport {
     let body = ""
     let size = 0
 
-    req.on("data", (chunk) => {
-      size += chunk.length
+    req.on("data", (chunk: Buffer | string) => {
+      size += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length
       if (size > this.maxBodySize) {
         res.writeHead(413)
         res.end(

--- a/src/utils/http-methods.ts
+++ b/src/utils/http-methods.ts
@@ -16,23 +16,27 @@ export const GET_LIKE_METHODS = ["get", "delete", "head", "options"] as const
 
 export const POST_LIKE_METHODS = ["post", "put", "patch"] as const
 
+function includesString<T extends string>(values: readonly T[], value: string): value is T {
+  return values.includes(value as T)
+}
+
 /**
  * Check if an HTTP method is valid
  */
 export function isValidHttpMethod(method: string): boolean {
-  return VALID_HTTP_METHODS.includes(method.toLowerCase() as any)
+  return includesString(VALID_HTTP_METHODS, method.toLowerCase())
 }
 
 /**
  * Check if an HTTP method uses query parameters (GET-like)
  */
 export function isGetLikeMethod(method: string): boolean {
-  return GET_LIKE_METHODS.includes(method.toLowerCase() as any)
+  return includesString(GET_LIKE_METHODS, method.toLowerCase())
 }
 
 /**
  * Check if an HTTP method uses request body (POST-like)
  */
 export function isPostLikeMethod(method: string): boolean {
-  return POST_LIKE_METHODS.includes(method.toLowerCase() as any)
+  return includesString(POST_LIKE_METHODS, method.toLowerCase())
 }

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -120,6 +120,49 @@ describe("ApiClient Dynamic Meta-Tools", () => {
       expect(result.endpoints).toHaveLength(2)
       expect(result.note).toContain("Limited endpoint information")
     })
+
+    it("should omit endpoints with excluded OpenAPI tags", async () => {
+      const client = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+        {
+          excludeTags: ["admin"],
+        },
+      )
+      ;(client as any).axiosInstance = mockAxios
+      client.setOpenApiSpec({
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/users": {
+            get: {
+              summary: "Get users",
+              tags: ["public"],
+              responses: {},
+            },
+          },
+          "/admin/users": {
+            get: {
+              summary: "Get admin users",
+              tags: ["Admin"],
+              responses: {},
+            },
+          },
+          "/status": {
+            get: {
+              summary: "Get status",
+              responses: {},
+            },
+          },
+        },
+      } as any)
+
+      const result = await client.executeApiCall("LIST-API-ENDPOINTS", {})
+
+      expect(result.endpoints.map((endpoint: any) => endpoint.path)).toEqual(["/users", "/status"])
+      expect(result.total).toBe(2)
+    })
   })
 
   describe("GET-API-ENDPOINT-SCHEMA", () => {
@@ -156,6 +199,41 @@ describe("ApiClient Dynamic Meta-Tools", () => {
       expect(result.operations[0].method).toBe("GET")
       expect(result.operations[0].summary).toBe("Get users")
     })
+
+    it("should omit excluded tagged operations from endpoint schemas", async () => {
+      const client = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+        {
+          excludeTags: ["internal"],
+        },
+      )
+      client.setOpenApiSpec({
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/reports": {
+            get: {
+              summary: "Get public reports",
+              tags: ["public"],
+              responses: {},
+            },
+            delete: {
+              summary: "Delete reports",
+              tags: ["internal"],
+              responses: {},
+            },
+          },
+        },
+      } as any)
+
+      const result = await client.executeApiCall("GET-API-ENDPOINT-SCHEMA", {
+        endpoint: "/reports",
+      })
+
+      expect(result.operations.map((operation: any) => operation.method)).toEqual(["GET"])
+    })
   })
 
   describe("INVOKE-API-ENDPOINT", () => {
@@ -187,6 +265,83 @@ describe("ApiClient Dynamic Meta-Tools", () => {
         url: "/users",
         headers: {},
         params: { page: 1 },
+      })
+    })
+
+    it("should reject INVOKE-API-ENDPOINT when the requested operation has an excluded tag", async () => {
+      const client = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+        {
+          excludeTags: ["admin"],
+        },
+      )
+      ;(client as any).axiosInstance = mockAxios
+      client.setOpenApiSpec({
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/admin/users": {
+            delete: {
+              summary: "Delete admin users",
+              tags: ["admin"],
+              responses: {},
+            },
+          },
+        },
+      } as any)
+
+      await expect(
+        client.executeApiCall("INVOKE-API-ENDPOINT", {
+          endpoint: "/admin/users",
+          method: "DELETE",
+          params: {},
+        }),
+      ).rejects.toThrow("Endpoint '/admin/users' with method 'DELETE' is excluded by tag filter")
+      expect(mockAxios.request).not.toHaveBeenCalled()
+    })
+
+    it("should choose the first non-excluded operation when invoking without a method", async () => {
+      const client = new ApiClient(
+        "https://api.example.com",
+        new StaticAuthProvider(),
+        mockSpecLoader,
+        {
+          excludeTags: ["internal"],
+        },
+      )
+      ;(client as any).axiosInstance = mockAxios
+      client.setOpenApiSpec({
+        openapi: "3.0.0",
+        info: { title: "Test API", version: "1.0.0" },
+        paths: {
+          "/reports": {
+            get: {
+              summary: "Internal report export",
+              tags: ["internal"],
+              responses: {},
+            },
+            post: {
+              summary: "Create public report",
+              tags: ["public"],
+              responses: {},
+            },
+          },
+        },
+      } as any)
+      mockAxios.request.mockResolvedValue({ data: { ok: true } })
+
+      await client.executeApiCall("INVOKE-API-ENDPOINT", {
+        endpoint: "/reports",
+        params: { name: "Quarterly" },
+      })
+
+      expect(mockAxios.request).toHaveBeenCalledWith({
+        method: "post",
+        url: "/reports",
+        headers: { "Content-Type": "application/json" },
+        data: { name: "Quarterly" },
       })
     })
   })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -815,7 +815,7 @@ describe("loadConfig", () => {
   })
 
   describe("Array Options Handling", () => {
-    it("should handle array options for tools, tags, resources, and operations", async () => {
+    it("should handle array options for tools, include tags, exclude tags, resources, and operations", async () => {
       vi.doMock("yargs", () => ({
         default: vi.fn().mockReturnValue({
           option: vi.fn().mockReturnThis(),
@@ -825,6 +825,7 @@ describe("loadConfig", () => {
             "openapi-spec": "./spec.json",
             tool: ["tool1", "tool2", "tool3"],
             tag: ["auth", "users"],
+            excludeTag: ["admin", "internal"],
             resource: ["api/v1/users", "api/v1/posts"],
             operation: ["get", "post", "put"],
           }),
@@ -840,6 +841,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toEqual(["tool1", "tool2", "tool3"])
       expect(config.includeTags).toEqual(["auth", "users"])
+      expect(config.excludeTags).toEqual(["admin", "internal"])
       expect(config.includeResources).toEqual(["api/v1/users", "api/v1/posts"])
       expect(config.includeOperations).toEqual(["get", "post", "put"])
     })
@@ -854,6 +856,7 @@ describe("loadConfig", () => {
             "openapi-spec": "./spec.json",
             tool: ["single-tool"],
             tag: ["single-tag"],
+            excludeTag: ["admin"],
             resource: ["single-resource"],
             operation: ["get"],
           }),
@@ -869,6 +872,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toEqual(["single-tool"])
       expect(config.includeTags).toEqual(["single-tag"])
+      expect(config.excludeTags).toEqual(["admin"])
       expect(config.includeResources).toEqual(["single-resource"])
       expect(config.includeOperations).toEqual(["get"])
     })
@@ -883,6 +887,7 @@ describe("loadConfig", () => {
             "openapi-spec": "./spec.json",
             tool: [],
             tag: [],
+            excludeTag: [],
             resource: [],
             operation: [],
           }),
@@ -898,6 +903,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toEqual([])
       expect(config.includeTags).toEqual([])
+      expect(config.excludeTags).toEqual([])
       expect(config.includeResources).toEqual([])
       expect(config.includeOperations).toEqual([])
     })
@@ -924,6 +930,7 @@ describe("loadConfig", () => {
       const config = loadConfig()
       expect(config.includeTools).toBeUndefined()
       expect(config.includeTags).toBeUndefined()
+      expect(config.excludeTags).toBeUndefined()
       expect(config.includeResources).toBeUndefined()
       expect(config.includeOperations).toBeUndefined()
     })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -839,7 +839,12 @@ describe("OpenAPIServer", () => {
       new OpenAPIServer(configWithAuthProvider)
 
       // Verify ApiClient was constructed with the AuthProvider
-      expect(ApiClient).toHaveBeenCalledWith(config.apiBaseUrl, mockAuthProvider, expect.anything())
+      expect(ApiClient).toHaveBeenLastCalledWith(
+        config.apiBaseUrl,
+        mockAuthProvider,
+        expect.anything(),
+        expect.objectContaining({ excludeTags: undefined }),
+      )
     })
 
     it("should use StaticAuthProvider with headers when no AuthProvider provided", () => {
@@ -851,13 +856,14 @@ describe("OpenAPIServer", () => {
       new OpenAPIServer(configWithHeaders)
 
       // Verify ApiClient was constructed with a StaticAuthProvider
-      expect(ApiClient).toHaveBeenCalledWith(
+      expect(ApiClient).toHaveBeenLastCalledWith(
         config.apiBaseUrl,
         expect.objectContaining({
           getAuthHeaders: expect.any(Function),
           handleAuthError: expect.any(Function),
         }),
         expect.anything(),
+        expect.objectContaining({ excludeTags: undefined }),
       )
     })
 
@@ -876,7 +882,28 @@ describe("OpenAPIServer", () => {
       new OpenAPIServer(configWithBoth)
 
       // Verify ApiClient was constructed with the AuthProvider, not the headers
-      expect(ApiClient).toHaveBeenCalledWith(config.apiBaseUrl, mockAuthProvider, expect.anything())
+      expect(ApiClient).toHaveBeenLastCalledWith(
+        config.apiBaseUrl,
+        mockAuthProvider,
+        expect.anything(),
+        expect.objectContaining({ excludeTags: undefined }),
+      )
+    })
+
+    it("should pass excludeTags to ApiClient options", () => {
+      const configWithExcludeTags: OpenAPIMCPServerConfig = {
+        ...config,
+        excludeTags: ["admin", "internal"],
+      }
+
+      new OpenAPIServer(configWithExcludeTags)
+
+      expect(ApiClient).toHaveBeenLastCalledWith(
+        config.apiBaseUrl,
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ excludeTags: ["admin", "internal"] }),
+      )
     })
 
     it("should create an HTTPS agent for mTLS settings", () => {

--- a/test/tools-manager.test.ts
+++ b/test/tools-manager.test.ts
@@ -122,7 +122,7 @@ describe("ToolsManager", () => {
         expect(Array.from((toolsManager as any).tools.keys())).toEqual([])
       })
 
-      it("should ignore other filters when toolsMode is explicit", async () => {
+      it("should ignore include filters but still apply excludeTags when toolsMode is explicit", async () => {
         const mockTools = new Map([
           [
             "GET::users",
@@ -150,11 +150,11 @@ describe("ToolsManager", () => {
         ;(toolsManager as any).config.includeOperations = ["get"] // This should be ignored
         ;(toolsManager as any).config.includeResources = ["users"] // This should be ignored
         ;(toolsManager as any).config.includeTags = ["public"] // This should be ignored
+        ;(toolsManager as any).config.excludeTags = ["admin"] // This should still deny the tool
 
         await toolsManager.initialize()
 
-        // Should only include POST::orders despite other filters that would exclude it
-        expect(Array.from((toolsManager as any).tools.keys())).toEqual(["POST::orders"])
+        expect(Array.from((toolsManager as any).tools.keys())).toEqual([])
       })
 
       it("should handle tool names in includeTools for explicit mode", async () => {
@@ -284,7 +284,7 @@ describe("ToolsManager", () => {
     })
 
     describe("Filter Order of Application", () => {
-      it("should apply filters in the correct order: includeTools -> includeOperations -> includeResources -> includeTags", async () => {
+      it("should apply excludeTags before other include filters", async () => {
         const mockTools = new Map([
           [
             "GET::users",
@@ -331,6 +331,7 @@ describe("ToolsManager", () => {
         // Apply all filters - should work as AND operation
         ;(toolsManager as any).config.includeOperations = ["get", "post"] // Excludes DELETE
         ;(toolsManager as any).config.includeResources = ["users"] // Excludes orders
+        ;(toolsManager as any).config.excludeTags = ["write"] // Excludes write tools
         ;(toolsManager as any).config.includeTags = ["public"] // Excludes admin-only tools
 
         await toolsManager.initialize()
@@ -338,12 +339,13 @@ describe("ToolsManager", () => {
         // Only GET::users should match all criteria:
         // - Operation: GET (✓) or POST (✗ - has admin tag, not public)
         // - Resource: users (✓)
+        // - ExcludeTags: write (✓)
         // - Tags: public (✓)
         const resultToolIds = Array.from((toolsManager as any).tools.keys())
         expect(resultToolIds).toEqual(["GET::users"])
       })
 
-      it("should document filter precedence with includeTools taking highest priority", async () => {
+      it("should let excludeTags override includeTools", async () => {
         const mockTools = new Map([
           [
             "GET::users",
@@ -368,18 +370,16 @@ describe("ToolsManager", () => {
         mockSpecLoader.loadOpenAPISpec.mockResolvedValue({ paths: {} } as any)
         mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
         ;(toolsManager as any).config.toolsMode = "all"
-
-        // includeTools should override other filters
-        ;(toolsManager as any).config.includeTools = ["DELETE::orders-id"] // Explicitly include this tool
+        ;(toolsManager as any).config.includeTools = ["DELETE::orders-id"]
+        ;(toolsManager as any).config.excludeTags = ["admin"]
         ;(toolsManager as any).config.includeOperations = ["get"] // Would normally exclude DELETE
         ;(toolsManager as any).config.includeResources = ["users"] // Would normally exclude orders
         ;(toolsManager as any).config.includeTags = ["public"] // Would normally exclude admin
 
         await toolsManager.initialize()
 
-        // DELETE::orders-id should be included despite other filters because it's in includeTools
         const resultToolIds = Array.from((toolsManager as any).tools.keys())
-        expect(resultToolIds).toEqual(["DELETE::orders-id"])
+        expect(resultToolIds).toEqual([])
       })
 
       it("should handle empty filter arrays correctly", async () => {
@@ -412,6 +412,7 @@ describe("ToolsManager", () => {
         ;(toolsManager as any).config.includeTools = []
         ;(toolsManager as any).config.includeOperations = []
         ;(toolsManager as any).config.includeResources = []
+        ;(toolsManager as any).config.excludeTags = []
         ;(toolsManager as any).config.includeTags = []
 
         await toolsManager.initialize()
@@ -486,6 +487,32 @@ describe("ToolsManager", () => {
       ;(toolsManager as any).config.includeTags = ["users"] // lowercase, will match uppercase "USERS"
       await toolsManager.initialize()
       expect(Array.from((toolsManager as any).tools.keys())).toEqual(["GET::a"])
+    })
+
+    it("should filter tools by excludeTags list case-insensitively", async () => {
+      const mockTools = new Map([
+        ["GET::users", { name: "users", tags: ["PUBLIC"] } as ExtendedTool],
+        ["DELETE::admin", { name: "deleteAdmin", tags: ["Admin"] } as ExtendedTool],
+        [
+          "GET::untagged",
+          {
+            name: "untagged",
+            inputSchema: { type: "object", properties: {} },
+            tags: [],
+          } as ExtendedTool,
+        ],
+      ])
+      mockSpecLoader.loadOpenAPISpec.mockResolvedValue({ paths: {} } as any)
+      mockSpecLoader.parseOpenAPISpec.mockReturnValue(mockTools)
+      ;(toolsManager as any).config.toolsMode = "all"
+      ;(toolsManager as any).config.excludeTags = ["admin"]
+
+      await toolsManager.initialize()
+
+      expect(Array.from((toolsManager as any).tools.keys()).sort()).toEqual([
+        "GET::untagged",
+        "GET::users",
+      ])
     })
 
     it("should filter tools by multiple criteria simultaneously", async () => {
@@ -605,6 +632,7 @@ describe("ToolsManager", () => {
         ;(toolsManager as any).config.includeTools = undefined
         ;(toolsManager as any).config.includeOperations = null
         ;(toolsManager as any).config.includeResources = undefined
+        ;(toolsManager as any).config.excludeTags = null
         ;(toolsManager as any).config.includeTags = null
 
         await toolsManager.initialize()


### PR DESCRIPTION
## Summary

This finishes and hardens the `--exclude-tag` work from #87.

Attribution: this PR carries forward the initial contribution from @Kaua-Klassmann in #87, "feat: add --exclude-tag filter to exclude tools by OpenAPI tag". Thank you for starting this feature.

## What changed

- Adds `--exclude-tag` / `excludeTags` as a hard deny filter for OpenAPI operation tags.
- Applies excluded tags before include filters, including when `includeTools` is set.
- Keeps `excludeTags` active in `explicit` mode.
- Applies the same deny behavior to dynamic mode by filtering endpoint discovery/schema responses and blocking invocation of excluded operations.
- Documents usage and verification expectations in the README and developer guide.
- Adds OpenSpec coverage for the new tool filtering behavior.
- Fixes existing lint issues in the HTTP transport and HTTP method utilities so the branch is clean.

## Product value

This gives users a simple way to hide admin/internal/unsafe operations from the MCP tool surface without editing upstream OpenAPI specs. It is still documented as a tool-surface control rather than an authorization mechanism.

## Verification

- `npm test` - 17 files, 417 tests
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `openspec validate add-exclude-tag-filter --strict`
- `git diff --check`